### PR TITLE
efficient single-pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ target/
 
 # Jupyter Notebook
 .ipynb_checkpoints
+.ipynb
 
 # IPython
 profile_default/

--- a/wavepack/wavelet_packet.py
+++ b/wavepack/wavelet_packet.py
@@ -7,280 +7,108 @@ import itertools
 
 
 # Precompute wavelet filters once
-def get_wavelet_filters(wavelet_name='db1', device='cpu'):
+def get_wavelet_filters(wavelet_name="db1", device="cpu"):
     wavelet = pywt.Wavelet(wavelet_name)
-    lo = torch.tensor(wavelet.dec_lo, device=device).flip(dims=(0,)).float().view(1,1,-1)
-    hi = torch.tensor(wavelet.dec_hi, device=device).flip(dims=(0,)).float().view(1,1,-1)
-    lo_rec = torch.tensor(wavelet.rec_lo, device=device).float().view(1,1,-1)
-    hi_rec = torch.tensor(wavelet.rec_hi, device=device).float().view(1,1,-1)
+    lo = torch.tensor(wavelet.dec_lo, device=device).flip(dims=(0,)).float().view(1, 1, -1)
+    hi = torch.tensor(wavelet.dec_hi, device=device).flip(dims=(0,)).float().view(1, 1, -1)
+
+    lo_rec = torch.tensor(wavelet.rec_lo, device=device).float().view(1, 1, -1)
+    hi_rec = torch.tensor(wavelet.rec_hi, device=device).float().view(1, 1, -1)
     return lo, hi, lo_rec, hi_rec
 
-# Then in your decomposition code, you do not rebuild them:
-def decompose_1d(data, lo, hi):
-    # data is shape (N, 1, L) for 1D
-    out_lo = F.conv1d(data, lo, stride=2)
-    out_hi = F.conv1d(data, hi, stride=2)
-    return out_lo, out_hi
 
-def recompose_1d(out_lo, out_hi, lo_rec, hi_rec):
-    rec_lo = F.conv_transpose1d(out_lo, lo_rec, stride=2)
-    rec_hi = F.conv_transpose1d(out_hi, hi_rec, stride=2)
-    return rec_lo + rec_hi
-
-def decompose_along_dim(x, dim, lo, hi):
-    # 1) Move `dim` to the last dimension via permutation
-    total_dims = x.ndim  
-    perm = list(range(total_dims))
-    perm.append(perm.pop(dim))  # move `dim` to end
-
-    x_perm = x.permute(*perm)   # shape (..., length)
-
-    # 2) Flatten everything except the first two dims (N, C) so we can
-    #    call decompose_1d on shape (N*C*extra, 1, length).
-    shape_perm = x_perm.shape
-    N, C = shape_perm[0], shape_perm[1]
-    L = shape_perm[-1]
-    
-    # Product of any intermediate dims
-    intermediate = shape_perm[2:-1]
-    extra_size = 1
-    for s in intermediate:
-        extra_size *= s
-
-    # Reshape => (N*C*extra_size, 1, L)
-    x_reshaped = x_perm.reshape(N * C * extra_size, 1, L)
-
-    # 3) Decompose using the precomputed filters
-    lo_coeffs, hi_coeffs = decompose_1d(x_reshaped, lo, hi)
-    # lo_coeffs, hi_coeffs: shape (N*C*extra_size, 1, L/2)
-
-    # 4) Reshape back to (N, C, *intermediate, L/2)
-    new_length = lo_coeffs.shape[-1]
-    lo_perm = lo_coeffs.reshape(N, C, *intermediate, new_length)
-    hi_perm = hi_coeffs.reshape(N, C, *intermediate, new_length)
-
-    # 5) Invert the permutation so dimension `dim` returns to its original place
-    inv_perm = [0]*total_dims
-    for i, p in enumerate(perm):
-        inv_perm[p] = i
-
-    lo_final = lo_perm.permute(*inv_perm)
-    hi_final = hi_perm.permute(*inv_perm)
-
-    return lo_final, hi_final
-
-def recompose_along_dim(lo, hi, dim, lo_rec, hi_rec):
+def zero_insert_1d(k, stride=2):
     """
-    Invert a one-level 1D wavelet decomposition (lo, hi) along dimension `dim`,
-    matching `decompose_along_dim(x, dim, lo, hi)`.
-
-    lo, hi: Tensors each with the same shape as x had after being halved along `dim`.
-    dim:  The dimension along which we want to invert the wavelet transform.
-    lo_rec, hi_rec: Precomputed reconstruction filters of shape (1,1,filter_length),
-                    e.g. from get_wavelet_filters(...).
-
-    Returns:
-      A tensor of the same shape as the original x (before decomposition).
-    """
-
-    # 1) Move `dim` to the last dimension (just like we did in decompose_along_dim)
-    total_dims = lo.ndim
-    perm = list(range(total_dims))
-    perm.append(perm.pop(dim))  # move `dim` to the end
-
-    lo_perm = lo.permute(*perm)  # shape (..., length//2)
-    hi_perm = hi.permute(*perm)  # shape (..., length//2)
-
-    # For example, shape_perm might be (N, C, ..., length//2)
-    shape_perm = lo_perm.shape  
-    N, C = shape_perm[0], shape_perm[1]
-    length_half = shape_perm[-1]
-
-    # 2) Flatten all other dims so we do a 1D inverse transform:
-    #    shape => (N*C*extra_size, 1, length_half)
-    intermediate = shape_perm[2:-1]  # dims between C and the last dimension
-    extra_size = 1
-    for s in intermediate:
-        extra_size *= s
-
-    lo_reshaped = lo_perm.reshape(N*C*extra_size, 1, length_half)
-    hi_reshaped = hi_perm.reshape(N*C*extra_size, 1, length_half)
-
-    # 3) Inverse 1D wavelet transform with conv_transpose1d
-    rec_lo = F.conv_transpose1d(lo_reshaped, lo_rec, stride=2)
-    rec_hi = F.conv_transpose1d(hi_reshaped, hi_rec, stride=2)
-
-    # 4) Sum partial reconstructions (lo + hi)
-    rec_reshaped = rec_lo + rec_hi  # shape => (N*C*extra_size, 1, length_full)
-
-    # 5) Reshape back to (N, C, *intermediate, length_full)
-    length_full = rec_reshaped.shape[-1]
-    rec_perm = rec_reshaped.reshape(N, C, *intermediate, length_full)
-
-    # 6) Invert the permutation so dimension `dim` goes back to its original place
-    inv_perm = [0]*total_dims
-    for i, p in enumerate(perm):
-        inv_perm[p] = i
-    rec_final = rec_perm.permute(*inv_perm)
-
-    return rec_final
-
-def decompose_nd_slow(x, lo, hi):
-    dims = len(x.shape) - 2
-
-    # Start with a single sub-band: the entire tensor.
-    current_subbands = [x]
-
-    for d in dims:
-        new_subbands = []
-        # Decompose each existing sub-band along dimension d
-        for sb in current_subbands:
-            lo_sb, hi_sb = decompose_along_dim(sb, d, lo, hi)
-            new_subbands.append(lo_sb)
-            new_subbands.append(hi_sb)
-        current_subbands = new_subbands
-
-    # After going through all dims, we have 2^len(dims) sub-bands
-    return current_subbands
-
-def recompose_nd_slow(subbands, lo_rec, hi_rec):
-    dims = len(subbands[0].shape) - 2
-
-    current_subbands = subbands  # list of Tensors
-    # number of subbands = 2^len(dims)
-
-    # We recompose in reverse order of dims
-    for d in reversed(dims):
-        new_subbands = []
-        # We'll group subbands in pairs: (lo_sb, hi_sb)
-        for i in range(0, len(current_subbands), 2):
-            lo_sb = current_subbands[i]
-            hi_sb = current_subbands[i+1]
-            # Recompose along dimension d
-            new_sb = recompose_along_dim(lo_sb, hi_sb, d, lo_rec, hi_rec)
-            new_subbands.append(new_sb)
-        current_subbands = new_subbands
-
-    # In the end, we have a single sub-band => the original volume
-    return current_subbands[0]
+    Zero-insert (upsample) a 1D kernel by 'stride'.
     
-def decompose_nd(x, lo, hi):
-    C = x.shape[1]
+    If k is shape (L,) or any shape that flattens to (L,),
+    the result is shape (1,1,L_up).
+    
+    L_up = (L - 1)*stride + 1
+    
+    Example:
+      k = [1, 2, 3], stride=2
+      => [1, 0, 2, 0, 3]  => length 5
+      => final shape (1,1,5)
+    """
+    # Flatten to shape (L,)
+    k = k.flatten()      # if k was (1,1,L) or (L,), now shape(L,)
+    L = k.shape[0]
+    
+    # Compute the length after zero-inserting
+    L_up = (L - 1)*stride + 1
+    
+    # Create an all-zero array
+    k_up = k.new_zeros((L_up,))  # shape (L_up,)
+    
+    # Place original samples at intervals of 'stride'
+    k_up[0::stride] = k
+    
+    # Return shape => (1,1,L_up)
+    return k_up.unsqueeze(0).unsqueeze(0)
+
+def cascade_1d_kernels(kernels):
+    # Successive zero insertion
+    ks_up = [zero_insert_1d(k, stride=2**i) for i, k in enumerate(kernels)]
+
+    # Cascade all kernels together
+    out = ks_up[0]
+    for k_next in ks_up[1:]:
+        ksize_next = k_next.shape[-1]
+        out = F.conv1d(out, k_next, padding=ksize_next - 1)
+    
+    return out
+
+def multi_level_1d_paths(lo, hi, levels):
+    """
+    Return a list of cascaded 1D kernels for all wavelet paths
+    in 'levels' 1D decomposition.
+    E.g. for levels=2 => paths = [lo->lo, lo->hi, hi->lo, hi->hi].
+    Returns a list of shape (1,1,L_cascaded).
+    """
+    return torch.stack([cascade_1d_kernels(p) for p in itertools.product([lo, hi], repeat=levels)])
+
+def outer_product_nd(filters):
+    # Start with the flattened first filter
+    k = filters[0].flatten()   # shape (L_1,)
+
+    # Multiply stepwise for each subsequent filter
+    for f in filters[1:]:
+        f_flat = f.flatten()   # shape (L_i,)
+        # broadcast outer product
+        # k: shape (...), f_flat: shape (L_i,)
+        # => shape (..., L_i)
+        k = k.unsqueeze(-1) * f_flat.unsqueeze(0)
+
+    # Now k is shape (L_1, L_2, ..., L_n)
+    # Put it into (1,1,...) format for a standard ND kernel
+    k = k.unsqueeze(0).unsqueeze(1)
+    return k
+
+def build_nd_wavepack_kernel(lo, hi, levels, ndims):
+    filters = [multi_level_1d_paths(lo, hi, levels) for _ in range(ndims)]
+    combos = itertools.product(*filters)
+    return torch.cat([outer_product_nd(kernel_list) for kernel_list in combos], dim=0)
+
+
+def fwpt(x, lo, hi, levels=1):
+    """Fast wavelet packet transform"""
     ndims = len(x.shape) - 2
-    k = build_wavelet_kernel_nd(lo.squeeze(), hi.squeeze(), ndims=ndims)
-    k = k.repeat(C, *[1 for _ in k.shape[1:]])
-    k = k.view(k.shape[0]*C, C, *k.shape[2:])
-    
+    k = build_nd_wavepack_kernel(lo, hi, levels=levels, ndims=ndims)
     match ndims:
-        case 1: return F.conv1d(x, k, stride=2, groups=C)
-        case 2: return F.conv2d(x, k, stride=2, groups=C)
-        case 3: return F.conv3d(x, k, stride=2, groups=C)
-        case _: return decompose_nd_slow(x, dims=ndims, lo=low, hi=hi)
+        case 1: return F.conv1d(x, k, stride=2**levels)
+        case 2: return F.conv2d(x, k, stride=2**levels)
+        case 3: return F.conv3d(x, k, stride=2**levels)
+        case _: raise NotImplementedError("Convolutions of higher dimensions are not supported.")
 
 
-def recompose_nd(children, lo_rec, hi_rec):
-    x = torch.cat(children, dim=1)  # e.g. (N, 4*C, H/2, W/2) if ndims=2
-
-    N, sumC, *spatial = x.shape
-    ndims = len(spatial)  # 1,2, or 3 for a single-pass wavelet
-    subbands = 2 ** ndims
-    C = sumC // subbands  # e.g. 4*C / 4 = C
-
-    k = build_wavelet_kernel_nd(lo_rec.squeeze(), hi_rec.squeeze(), ndims=ndims)
-    k = k.repeat(C, *[1 for _ in k.shape[1:]])
-    k = k.view(k.shape[0]*C, C, *k.shape[2:])
-    
+def ifwpt(x, lo, hi, levels=1):
+    """Fast wavelet packet transform"""
+    ndims = len(x.shape) - 2
+    k = build_nd_wavepack_kernel(lo, hi, levels=levels, ndims=ndims)
     match ndims:
-        case 1: return F.conv_transpose1d(x, k, stride=2, groups=C)
-        case 2: return F.conv_transpose2d(x, k, stride=2, groups=C)
-        case 3: return F.conv_transpose3d(x, k, stride=2, groups=C)
-        case _: return recompose_nd_slow(x, dims=ndims, lo=low, hi=hi, max_level=max_level)
+        case 1: return F.conv_transpose1d(x, k, stride=2**levels)
+        case 2: return F.conv_transpose2d(x, k, stride=2**levels)
+        case 3: return F.conv_transpose3d(x, k, stride=2**levels)
+        case _: raise NotImplementedError("Convolutions of higher dimensions are not supported.")
 
-
-def wavelet_packet_decompose_nd_to_leaves(x, lo=None, hi=None, level=0, max_level=1, leaves=None):
-    if leaves is None:
-        leaves = []
-        
-    # Base case: if we've reached max_level, store x as a 'leaf'
-    if level >= max_level:
-        leaves.append(x)
-        return leaves
-
-    # 1) Decompose current x by one level across all dims
-    subbands = decompose_nd(x, lo=lo, hi=hi)
-    C = x.shape[1]
-    subbands = torch.split(subbands, C, dim=1)
-
-    # 2) For a wavelet *packet*, we recursively decompose *every* sub-band
-    next_level = level + 1
-    for sb in subbands:
-        wavelet_packet_decompose_nd_to_leaves(
-            sb, lo=lo, hi=hi,
-            level=next_level, max_level=max_level, leaves=leaves
-        )
-
-    return leaves
-
-def wavepack_dec(x, lo=None, hi=None, max_level=1):
-    leaves = wavelet_packet_decompose_nd_to_leaves(x, lo=lo, hi=hi, level=0, max_level=max_level)
-    stacked = torch.cat(leaves, dim=1)
-    return stacked
-
-
-def wavelet_packet_recompose_nd_from_leaves(leaves, lo_rec=None, hi_rec=None, level=0, max_level=1):
-    if level >= max_level:
-        return leaves.pop(0)
-
-    ndims = len(leaves[0].shape) - 2
-    subbands = []
-    for _ in range(2 ** ndims):
-        child = wavelet_packet_recompose_nd_from_leaves(
-            leaves, lo_rec=lo_rec, hi_rec=hi_rec, 
-            level=level+1, max_level=max_level
-        )
-        subbands.append(child)
-    
-    # subbands is a list of Tensors => pass to `recompose_nd`
-    x_merged = recompose_nd(subbands, lo_rec, hi_rec)
-    return x_merged
-
-def wavepack_rec(x_stacked, lo_rec=None, hi_rec=None, max_level=1, original_channels=1):
-    # Number of final leaves for wavelet-packet:
-    # In ND, each level => 2^(len(dims)) expansions. Over max_level => 2^(len(dims)*max_level).
-    num_leaves = 2 ** ((len(x_stacked.shape) - 2) * max_level)
-
-    # x_stacked is (N, C*num_leaves, ...)
-    N = x_stacked.shape[0]
-
-    # Split into final sub-bands
-    leaves_list = []
-    chunk_size = original_channels
-    for i in range(num_leaves):
-        c_start = i * chunk_size
-        c_end = (i + 1) * chunk_size
-        leaf = x_stacked[:, c_start:c_end, ...]
-        leaves_list.append(leaf)
-
-    # Now recompose from leaves
-    leaves_list_m = leaves_list[:]  # shallow copy so we can pop
-    x_rec = wavelet_packet_recompose_nd_from_leaves(
-        leaves_list_m, lo_rec=lo_rec, hi_rec=hi_rec,
-        level=0, max_level=max_level
-    )
-    return x_rec
-
-
-def build_wavelet_kernel_nd(lo, hi, ndims=2):
-    combos = list(itertools.product([lo, hi], repeat=ndims))
-
-    kernels = []
-    for combo in combos:
-        k = combo[0]  # shape (L,)
-        for c in combo[1:]:
-            k = k.unsqueeze(-1)
-            c = c.unsqueeze(0)
-            k = k * c
-        k = k.unsqueeze(0).unsqueeze(1)  # (1, 1, [L, L, ...])
-        kernels.append(k)
-    
-    return torch.cat(kernels, dim=0)

--- a/wip.ipynb
+++ b/wip.ipynb
@@ -1,0 +1,1636 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2e6f4ff1-322a-4e07-ab9e-289270856d10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0f94dc22-87ca-436c-9f0b-39f3070442e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from wavepack.wavelet_packet import *\n",
+    "import torch\n",
+    "import numpy as np\n",
+    "import itertools\n",
+    "import nibabel as nib\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7125d09f-fde2-4fea-ba6f-ce99203b335c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "device = torch.device(\"cuda:10\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "156d5b15-6c99-4c84-9484-be01f0cdfd20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lo, hi, lo_rec, hi_rec = get_wavelet_filters('haar', device=device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "79bff1f2-57f0-4d0c-ae93-00c9bc509629",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "levels = 4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "dc625a47-67b0-4d2f-8b1f-a35b02c2ffa0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = nib.load(\"/ISFILE3/USERS/remediossw/data/OASIS3/orig/sub-OAS30003_ses-d0558_run-01_T1w.nii.gz\").get_fdata(dtype=np.float32)\n",
+    "x = np.pad(x, ((256-176, 0), (0, 0), (0, 0)))\n",
+    "x = torch.from_numpy(x).unsqueeze(0).unsqueeze(1).to(device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "b9959edb-a900-4987-8292-ea4696002652",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w = fwpt(x, lo, hi, levels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "7230afba-f3e6-425a-9b92-8b5c1749b4fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_hat = ifwpt(w, lo_rec, hi_rec, levels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "84bce5a9-de4c-4c5d-922c-107c2e403f83",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 256, 256, 256])"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x_hat.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "ee2b0707-8af2-49ce-b275-d078689bb721",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 256, 256, 256])"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "b450a16d-93a5-4bed-ba88-9168dc257862",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(0.0005, device='cuda:10')"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(x - x_hat).abs().max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1a42cc30-0f39-41e7-a805-5e8c2764a551",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 119,
+   "id": "725bc2f1-4560-412c-b2c6-63ef7a7053e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "w = F.conv3d(x, k_dec, stride=2**levels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "id": "74cb627d-ec7e-4677-b3ae-2065062b43a3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 4096, 16, 16, 16])"
+      ]
+     },
+     "execution_count": 120,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "w.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "id": "c574d16c-4c69-475f-aa71-edf8b9e1df68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x_hat = F.conv_transpose3d(w, k_rec, stride=2**levels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 122,
+   "id": "db06a0e8-4660-4539-86a1-2db591fca832",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 256, 256, 256])"
+      ]
+     },
+     "execution_count": 122,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "x_hat.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 123,
+   "id": "e187c846-14fd-48f8-8e1f-e656e812bf3b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 126,
+   "id": "375fc4c9-7565-46e3-bdf4-e7352c500638",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.image.AxesImage at 0x7f4fce56ae10>"
+      ]
+     },
+     "execution_count": 126,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAa8AAAGiCAYAAABQ9UnfAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOz9adA1yXXfB/4ys5a7Pdu79Pv2CjTABomNiyAbJEyKlLhoJMshWooxZU0oOA59kMMxMYGgaEsMfREdDDBIRzA0M7Zs88OEaMdQVsSMbMk27RFkDylpII1kSCABEEujAfT67suz3OfeW1WZOR9OZlVW3ft0A0RD0APWP6L7fe69tWRVZeXJc87//FN57z0jRowYMWLEJYL+VjdgxIgRI0aM+HoxGq8RI0aMGHHpMBqvESNGjBhx6TAarxEjRowYcekwGq8RI0aMGHHpMBqvESNGjBhx6TAarxEjRowYcekwGq8RI0aMGHHpMBqvESNGjBhx6TAarxEjRowYcenwLTVef/2v/3Wef/55JpMJH/rQh/iH//AffiubM2LEiBEjLgm+Zcbrb/2tv8VHP/pR/spf+Sv8i3/xL/ihH/oh/tgf+2O88sor36omjRgxYsSISwL1rRLm/fCHP8wf+AN/gP/8P//P2+/e+9738pM/+ZP84i/+4reiSSNGjBgx4pIg+1actKoqPvnJT/KX//Jf7n3/Ez/xE3ziE5/Y2n6z2bDZbNrPzjkePnzI1atXUUp909s7YsSIESPeXnjvOT095amnnkLrrz8I+C0xXvfv38day40bN3rf37hxg9u3b29t/4u/+Iv8/M///L+s5o0YMWLEiH9JePXVV3nmmWe+7v2+JcYrYug1ee93elI/93M/x8/8zM+0n4+Pj3nuuef4Qf44Gfk3vZ0jRowYMeLtRUPNP+I32Nvb+z3t/y0xXteuXcMYs+Vl3b17d8sbAyjLkrIst77PyMnUaLxGjBgx4tIhsC1+r6mfbwnbsCgKPvShD/Hxj3+89/3HP/5xPvKRj3wrmjRixIgRIy4RvmVhw5/5mZ/hz/25P8cf/IN/kB/4gR/gV3/1V3nllVf49//9f/9b1aQRI0aMGHFJ8C0zXj/1Uz/FgwcP+I//4/+YW7du8YEPfIDf+I3f4B3veMe3qkkjRowYMeKS4FtW5/WN4OTkhIODA36EPznmvEaMGDHiEqLxNb/J3+H4+Jj9/f2ve/9R23DEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6jMZrxIgRI0ZcOozGa8SIESNGXDqMxmvEiBEjRlw6vO3G66/+1b+KUqr3382bN9vfvff81b/6V3nqqaeYTqf8yI/8CJ/97Gff7maMGDFixIhvY3xTPK/3v//93Lp1q/3v05/+dPvbL//yL/Mrv/Ir/Kf/6X/KP/tn/4ybN2/y4z/+45yenn4zmjJixIgRI74N8U0xXlmWcfPmzfa/69evA+J1/bW/9tf4K3/lr/Cn/tSf4gMf+AC/9mu/xvn5Ob/+67/+zWjKiBEjRoz4NsQ3xXi9+OKLPPXUUzz//PP8mT/zZ/jyl78MwFe+8hVu377NT/zET7TblmXJD//wD/OJT3zim9GUESNGjBjxbYjs7T7ghz/8Yf6r/+q/4j3veQ937tzhF37hF/jIRz7CZz/7WW7fvg3AjRs3evvcuHGDl19++cJjbjYbNptN+/nk5OTtbvaIESNGjLhEeNuN1x/7Y3+s/fuDH/wgP/ADP8C73/1ufu3Xfo3v//7vB0Ap1dvHe7/1XYpf/MVf5Od//uff7qaOGDFixIhLim86VX4+n/PBD36QF198sWUdRg8s4u7du1veWIqf+7mf4/j4uP3v1Vdf/aa2ecSIESNG/KuNb7rx2mw2fO5zn+PJJ5/k+eef5+bNm3z84x9vf6+qit/6rd/iIx/5yIXHKMuS/f393n8jRowYMeL3L972sOHP/uzP8m/9W/8Wzz33HHfv3uUXfuEXODk54ad/+qdRSvHRj36Uj33sY7zwwgu88MILfOxjH2M2m/Fn/+yffbubMmLEiBEjvk3xthuv1157jX/33/13uX//PtevX+f7v//7+Sf/5J/wjne8A4D/6D/6j1itVvwH/8F/wKNHj/jwhz/M3/t7f4+9vb23uykjRowYMeLbFMp777/Vjfh6cXJywsHBAT/CnyRT+be6OSNGjBgx4utE42t+k7/D8fHx7ykVNGobjhgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH0XiNGDFixIhLh9F4jRgxYsSIS4fReI0YMWLEiEuH7FvdgH/lodTFv3n/eztG3C/9Pv3uaz3u7wW7rucbaU/cR4V5kHeyffw+/p3+ftF5h+eM+6X77Gr7Rff3ovYOfx+2L23Hm7U7bftwu+ExnN15ncoYvLXb15Fe9/AexM9v9twAtNluz7Ddw7Ym16K0kral2+26novuybAfDLFru13t2YWL7m/8+6JrHe779faVbwTD4w3blT7ni86bHuOiv4fH/nqv4Zs9Br1NuNzGS6mLB6OIYSdPX/qLtk9feqVRevcg1r7YbzEwK2Pabby1oGRbZUy3uUvb5PrH/FrbPfwufr9jUOq1B2m3yvL2nLE9Siv5ezh4QhgwNMoYlAnHaxp808ig7Dwg16myDLTGrTdy/vZedPe3N1DiUEWBMkb2ifdqYMi8td391Qqs7R9n8GxaY5HexiyXfUH2D9ebfu/rprsfTdPd63D9aIVSCm+d3L+mAW3a33zl2nb6pm7boooCqgrvfHuv4/30TdO7rvZaBtepsjx5Zl0/UXkG4Vp8un84d2+f+BwAjEEpBcZAVXfbKbl+lWW4Kt5e1f4W73N8Vt7atk+JgR4Y43DOeM3tdSV9b+sZxn7b1F2bjcHXdH9X/XdFGSPXEo+dvH/e+W1jBzIGAPHdaHGREX6zyUb4ThnTPnvonlu7T9rXQht719/umNyL3uuejFmmG8N2XmMcN+N1xt+HE6ohdPIeDsfKtK3Obm87vE/foH283MYLds7e05enN7vzyQPUneFoZ5jxBicPUl5cDdj+7G7oYSS/tS9079hh8MsLaU7j+kYhGTy8JemcycOOg2EcjNJrT66n18705Yududk2dL0XK3lZWqOaDDhpx23bHAfacNzWMIUBwlfdS9sOuuEl8U6jcoXyqn2Jfd3ISxyMk7dWBs6yxG823f1NjJpSGd4YVDAQvcmB7a5na9LgHVhaAyI/JN8nxs43/cmA0qrdziXGWOWFXJu10KSDigZv2vsYjbnKMzFk6418X4V7pB043RvcSO5fPKb3ClzTTUAIg2A0EkXR7ued3zbw3sk9UhqFxSsNTdM9/9h3hvcjvipF6NeJIW6Nf7yvKu/6Lolx8g4wYmjbJnUTHGWkXd556SdKyT2MbY/3wrt2kpF6797anvGXY5v2b8+O92qX8cmz7vhpG9uJhxxfFznee3C+NbLxOuNz8Nb2DZkBXyXvtO4mvNEQpH3du13eeLx/rhtDdkU3dhnmxAjtNFzDcS4iNYphvJRxa+hVps+a3Ybx68TlN147PK/uhUsHmh0eWvJCttuk/w6223oAO8MRrmcjY4duP/fCMH3DMtwW6F4K78J/6Wx0x0xP6b4hoxvg2xnYrnCNCgb6IrSd7oIQXhwAne8G9XZgoTdgxevsbRtmxe1gncyyZUYeBonWQIRzmW7Q872wyXC2qi/4zbaGQdHN+of3sEUw2H1Pefc5dZHjrcM33b2LBqKFdzKoQ2tc4vV1E4Xwd/Sieue2rdfbGoN43PTvcK9luyR6MPSqQz9s7+8Ob6L1dH2yzTAK0Z538Bm2Jw872itt6L9fbT8hGjXTThzSbbbf58E7mHi5/XNeEL2IfdTtHmeGk1WgfVbpu+edR6lkbNp5LrWjf6iu7wza9ZbvZbqtNKw/SX6rfYdRG5Pct8Tb7mHY975JuPyEjaGVj9bfDWaWw+3SGUDbkXR/+53n2jEoxg6WHm9nXiV4dbFtw/Pucr8HiC9Bu5kJ3o/f8V1EnKGn36X3I/WqQjuUVoOZ8fBeDO7l8AWOYSCtUGYQkmrb3A8xtdcXZn7tcZLr9VbO1R4nCVnifDdoDAa+HkK7iF6TVl1oKV5enm09g3i+3fcy8ZzjgJ7nXdvSa0v3i3C+N6snXlfqBach0WjUQl9SSUTAJ6G3dN/2msPxu+ed9Nfw79Co9UJ4wQsh6Wdp23be+xAWjhMWYsgu9LvYXvluYDSTe+KdFy/f+/Zd2HW9u+7xVrvaCeEOQ71jvzb0Obj3Q3jv+9c6OIZ8P+g/g3u78x7Gc34txiadYCvVvc/tWHhRjnb3GNfubzqPVSXv4IXjYvr5gjHt94rL73m9VVw4hgtTr6rnqeyYnSUhu17OZ/Aw0hlMOsPanoklA3Q6o1f0OkQ3s+4PWO3mO/I1bagrya31cipZidts+jO9cE9UXsi2zsqlhdBE+4INZspt3iT9Pr74zaYLIw69hLzrZr6qtgZkpRWqKLowF9IW8RSb7pl4j09yJSrL2n28tb2QzBaScExsQ/vyxT4Q2hLb2XoISqOLLhzn1uv2XimjQXf5Q2WS5xhCgOkA5p3H15WEj9NBMf4ePUsMrqmSC+jCsPIMusHNhbxUbGsvR6sl77VlNNPQY571c2gxB9n073X77GN4Lplc9AfnJJeVq+7YyYDpq+A5Ic9ZtYOikzbvQBcGHbzDyb0F+rnbNK9qjHg+sb/EXGHTkOYK2/cSw06jGJ+D7l9bvG/KmG4ikkQN2vEoec/iPemlLXrRhQvyg4Cvq37oPu4Xwpu7c8n00wPJONjLASYpkHZM8V6crdYL7BONehGeNGQpjetP8N8GXH7jBZ2Bihh6Yul20TMb7j9MzL7lORMjM5itdmE+j8ds7bc1c0+8jp4HlEL1z9Ve2zDcGDtNiPXHzt51yi7c2OWltsMkvXsUB5b4IsQBLeRalPJ4Z/vXFPbTWXixYigsGRBS46CUeAVtDmXo2fjEq4mX6gdhtDTZn5I4SAY+3ydigJHjpM8g7D/0PmIeI+1T3jpUNF7JgNFNSMIgZC2E3IpvZ+66Gwjjs0v7Rjpr700adJsT6+5VPwfUtjvN5Q2Netw2evMxH5J6AikSA+mtbXOUw/a3hw8kifbv6EUnHrfsT5sb6yZj8ThpWNd0uZz0GZFcY9rOZBvvPIrUgKaelkKXpYR4h/eo9567fr8aeFftuZ3rjOnQ+KUTPJUO7l2/kmvqT1rbc7oujzn03lSbyupPJobX0CJNIaTX8CZpky1jnub5k7FBzrcj56Z0f6z+BnD5w4a7sCt0NwiLAINO9yYhvOE27efOGxvGz7vzvUmOKOzXhcouiF+/lbv9ZmGEGFYK3ll7vDAY9kIJ8XTxZYnep1KtcemOFQbW+P0wBOldx1iDsM0gdJB6YMOwRRLCa2f4Q6N/EcL+yujWs0pDG8p016RUyGUMvE1iPiX0o9ZwXRTPd66b6YdrT+9Z267ewJxc3457m35uQ4jDgXJw3WmYEuj1q17IeXic4NGk9zcNHXuf7KvjpCkaokF4NV5DmldKPNytAfCiXF3aFjUIP0cDdkF/SK+1N5DHaw8DcRrGTI8/DM+Hm5AYEd/3VNPNbNe2LWZr+u4Mje0wnDeM9vQvcPu7Qf/o9ef0WBeE8C4KvW4brAvGo+Fkclf73kZcbs/Le0j5lrsIFBfWSySzS9+5yf19rbC40u1SyifsNjhDA7nl6QW3O2UFqv6L0+6esMeG19ijSA89tqHL336deA0u5hoGs/gwy43HdlU92E/2aZPm0DMO7XZNA02DyjKhkWt6obn0WFhQeSaeWvRkklm6r6rt0oRBaFZlWcuQa8MyVSXU/bJEaQmn+Mii865lycXn0sIlfUebvteS9A09KzvjFj1eJ+zKlK6cMu+Ajp3X1F2YMdyrSLtP+1bqaQ2fcUvd16bzNHcYqXQQ12UmnkZdhfZl/fA1CLMzhiTbPpZLiLequn6c5gq1MELxHrfe9JrrNt1n34TwmQ4s0eSdieFXpbo2+aYRA5NlQtVfr7trDO9RS/IwpiXfDMOluzwrvMet1v1J5678uDZt+KzdJt6DNMriqm5/72UMURqV5WEysSNs17tRsZ8nYT/l5TWN50smoL7n3bM9NrUTyhhVCP0gjQpddO0D9FIXSSSr50wl0Z8ttvdF5U2/B1xu43UR4o0b1iCkvw/zYDCYmdD/DraP1w5MWfciJTH5NnSQdqb077QOAtqXT8UcRJo3IpmFJzPb2KG7Nqp+Xk2rvpGLHX7wUqcDbUsrTkIRrUeR1KZ457vZsesbznTWHGeiaIVezEMIT56R8hk41w1eOoRDduT2em0NbWrzMXkOdaQl266eTGkxXEq1YUZUTswnpHmyNMwl5+q8oWgQldG95+F7+SbVy7eIseo8UWzX/rZubFAGEEknXtPzVkhLEbRCpXmhNJSrFJ5BaC7ct9QLc7F0Ie0r4Tht36g6b0UZuhxnapSU7vI77USj7vfJcOytnEp8rnbbw5A8akLVBwlP+xAKz5I8qlf9nDNdqNIP3o9ughgni4PwcEuxH+S7w/W1Y0MSukwniJF6nxq8tp1t2Ue4VzG8FseM9B7sYh3KxfYZrzHloXKGk9AeSzkeM97b9JiDc6b5wzaHH+1VW4JiesaynUTtMkopq/ltxOUOG6aW/Wu5OV+L25qy9gahrl0htm82UrLIlju+FdZw3Xc7tn9LBh5sn2O4z66wRzx3OkikYblhyCIaKNmw9bS6Y3l6+Sw3YA++ReiwlzPS3cCW0sV727luEkIvvGjEGEWDGUN7xrRsu5hX7E1S4j26KNwSJg/e2jY8KTTq5Lqc3zI+kbmZ3t/ecdv7t2PCNgxfDu7XVpgseWbbYbGOPDLMTe5i/6X3R8XJ1Y4+NMwfbRGlkrDshdj1nnwt72w7WTOk4dNhGLe3y/D5kLw/F4UA3yyN0EaDLj7n9n5fh1F4q/twwW9vGgbsRXvU7t/VN2fcvNye1zDMNzRkw4K6dr8dnSN1dRMPqT/7GrjZscNuhSJCWMkNzpUSS3YRRyLS/EtvJuNowxBp8rkNH4QQXLuf26E4kXgwg5yCJ3lZY9uc7s+wlOpmv6mHGEMdOgzs0M9jReO4WiW3Kbm2wBb01vZZh0qL5xa8wLbg1Bi0CeoNTYPfbNBl2ZJIdJFQ351rPY3Wwwxtcsvz9nuViwoIdY2ravR81u4fQ5euqoV5mIdzJ8zFVgnDhcLhVolDd6FAwG26sFGveHhHcWwkEbSsSK1l4p+w2XpqCuk9Tzw8Ccd2oTWVZb083q68UI/ZljDUIjsU54JXbbtnXiUMybQfBe9EFQW6MLjVCpXlLVsz7tcjn0AbIhNvtTt2G2KVi94yvCkbLm63e5vQvEAoUcZAZMS2Yd4kTJYQuyJDNrL+0jGkx9BNyRhJAfAwzLflCSbvd5/1F6IGxoBX7YRh57Xt8iAvMsZ6cKy4b9LmHmkjHQNdQgyDXq59iyyitNzHbzByeLmNl3egc3q0+NRYbWm7pTmNJN80iDG3ns5WeHwwuFw4i9p2v9vvtwqD2eoE3fa6b+ziNQ3PvSvvNjSaiVTRFvEAujwQiJFo29Gf6bpUKaNupCZFBQp7u5GEd2TQ0RLGgi50F8KNbfgseh4ukDzyDF9V6LIMnkmXP9Fl2bIDe4oWUYYoDgx1I5HfAY1XpJq6nIoPvymjeyogyhioayEqBNq8KgrM/kLua5gUmL299ry+qmRQD89Zz2ZijKtacnZhENZl2d5vv950zyl6YuH5xAE+FjvLvRWDEZUbtMlDLlEGQxX6jcoH1w1hcA7PoelqynpU77QfJSHEmK9JSwnaexWNttLo6bTfxgQqXJsPEy/f1Pim38Y0jxrbAGwdC90vG+kmYrvLSeJ1pYM6IczZ5vDCM405ppZNOTSo4XiuLYVIJrwKKT3phd4T45GGHdvJW3x3tlmb0XjEvFbSiC4kmuaq0vzWkI0c+9lQFWOX17h1v1Tv+952sUk7Qu7DMPHW+b8BXG7jBYMZSmIcBl5J+3e735A2vMtD0wOppbjvm8Rwk/NtGbuLzvNW1/S1YFd8fNc5B3m0iw83eOF25g6TMGU6e9QKX4tahvfhxXYarwkx/0pyQcEbaOnk3rfhsLR1W55tDEOFCUn3Yg9mlC7mHaKE0nZIJ8oyqSyDLAusPiVGJBPDyaaSz3mGDx6GqhuUdfhJAVlgNNowaHgvv5U5qrHoqoZN1RluZ1HWikGyyYvtJUTqNYFGH3KKWkvOixByTXIyEO4psNVTUnYgdGHGNEyrEop1+9wHUYfeI/ftgNq2IeYKvUvu+Zv02wuOGXMraU6x14aLctjBG9gqr5CTJSfqxoaeR+CS9zVul/SrIWsxafiO830dGLzbu97JLSp+cr40F7XVpiHhZBjeezPCRMxdDpVu0uPv2GdXGU/3+9uf97rcxsv7HW/sDgQ3tfciDEka7TET11+r7We1i34/9KTS2U/bBrW1/XbSdRBeDASAXpx/Vyg0hq1is5qh8erPqncmbIczbxVe3MaHmWOYqQ5yY1uz3xB6EY07nUguhbqgoug+61J2jDPbQFSIahE+GINUo69Xi5OEh72jl8RXRneUZZB2eQmJ6CJvB3BdlqiygLLAzybYSYHPNW6a0UwMyoPZWLxWeKXa/qY3FuU89X5BM9O4TOEMZGuPrj3Kelyh0I181pXDrBv0ukGfhFCltfjzdWdYncefn6O8hyyQWdKcYFTssCkhR4xtG8aL3qPzXXLdaTCJ4RqUDYguYpioxELe8BuJhxZnzDIhCe9efN7hfG2xeOhTKVqPRicD23BgTiaMMTTWkmsGRKaeJ5CG0hLCRgyrtf0lMbiR2JFGE/oN7piE8bp7NW1Jm1sW3o7r2qbcS79uiV7pu93d7O7wqScaz9fm3wcRpa1riNeenDv1/pJr6Wob4+Sou6fe2n6EangP3oo9mI5ZI9sw4E0MWM97iDTRNrZPMgPbMZiHgS59UFJgqtrZdW/GPNTCiwZzEBLpHX/HTEterKK/T9q5BrHtbrvBub2TQT2EPjqDkXS8hLnUnSuZ5UJ/VhuEVdvZeqLy0F6LtbjIJmSQJ4Q+U62ue4ZJz2cyOEV1C+9Cai8Ytxhyq6pgmEx/4Leh5iiEGhWI1zWdoGYz8ZKmBb7IcIXBlQY8eKOwpeb0mQxdg6k9poJ6psCDqTKytRfjpxT1XFGcGnTlOXs6E4PrQVnYHChcrrAlTB54so3HVB5bZHhd4JVC+X3MxmNqj954NocGFJjKM7lfgwKXa8zG0kwM3igmd1fY3KAbh7l/gj9fCamjyMVorVbY5Tk4i55MJBTWZF1/0Vo8jPBfKjPVPV+NLoMii/OdoYueR2BDCtU+6DbWTRuO7tiEISwcPbTYd1036Oppp6iisqyblOyIdLShJ7tDQHu4bcJq7CnPK90aMjle03v3Y85OvPohE7c/Yesx+UDes8H2rTeZZV1IPglBdh5Vkk/boafZqxWLYcjeO7zD++t5S67dZxeRJVXJ6SYFw6VwkvOkuT36E8bUEL+p2s3bhMtvvLa8kEEMNx3gh0ZqR15rp1EKD6vtcHHW0npaA0OZemC9tg1ixjv+3hXb7nXY9FjJvrs757ZV78e1d9ybC1z7lgwCbfuGuZKt/F5M+vdCPx3N2w8p0mlnT/IM7VIj8ZzQK4yVPJlBTSfEkJ+aTeWZZQa/mNJMc3yhxRhohZ1obKlQ1ovxysXorK+KMdM1uCLaZ4XZgNfhv5zgiQE6bBP/c+BKhz1oWD/Iyc80ZgX1vic/VWTnYCcKbzrbn63AbDzZuWL1nSUEQ6htji3knM1sjm48yoJ6YkLxqEKvGvSmpjmaoWqLPq/RDx5Dlkkos6q75xkmBYRwpbKdBmLfaw/GKM5djAEVJJQGSuZCtlBdqDB6bS3RIW6YhJTju1l3ZBafTCy3FGnS7weextbAGc+xCzHikObzel5PEk5PwpNbkYatnLS72JA6D3Z32LE3EY1jSnq9yXvalqukxDGlt3OKbVu3w/y7mMc+veZhqHBXHj4NBQbvaSezM9zPt0pNfKO43Mar54ruyMvEDhW9iZS8MXRdh8cCtiybT4VkL3hREk9w2PF3hi3Tv9PC6CT0qLJBqKINUwy+S+LzvfvxZiEakpfiorj91osQDFa41q08SGxb71TJi5tl0vFtuyiU7J+wDDv5INUywNocEYhHlWVdgr/I4XAf5TzeaOrreyjncZmmOiywpRgnl4nhsSXYUomxyZFVShysnrT4hYVaQeZRmSMrLFWj0caT5RbnFEd750zzmtfuHaGNI8ssk6Lm9GzKbFrxnqv3ePn4Co9PZqxOc+bXz1m+tqC8b6j3HXbhIHeo3JG/XFKcKmwBp887dKMwK4XXHp8BHuo9Q37qUQ6qA8XkfkZ56igfNZy8owAP+cqzeEWMH4BeN/jS4JXCnG7QyxU0FtU0eKVwm414TpNSDFDIuZHnHakjUMclHJkwyELYS2mNX29a1iAqqdlL+1zaH7US7zoWbqfkhrQPh21jTlSWk0lCeYGBGRmP6fnakNeuSWXoX+ng34nu+rCcDe0+u7UyXdvmcADSXFncZri8UcscNVpYijGUmbZnULPV6kcaupRA+/4NUhbx+Vzk8Awmwn0mYSx2HjyvYb4q9eqGaYx4/KFX2Lt3b49Ru9zGC9oBv2cAhjHg4aJo7XYJep0wdDZtkhnVwLuIYcVh3qu3Ls6gqU36UsZwXaIgkHbE3gwn8TqicWzzTyaZAQaWWdtGMShbi0xe0Kl6NPnwby/m3c7O5NpVXvTadhGtOk2m+6CyEFleyrle3ZdvmjYU5asqCS3lyQCpJBS4vwfTkuZgQnVYUM+15JwqJ2G8cL9141kfGZoZ1HNFvQ+29LjC4W9syIuGPLcY7fjjT32Fq8UZnzu9yV624cnJMd89e4X35HdZ+pzHbsbt+pCX1k9wa3NAaRo+ePgGz5UPeSp/xGM7wyjHnl7z6pUrXM9OeWd+j1xZHn73ggd2wVc21wG4W+3xj28/z/zmQ144uMefvvq/8XcffR8PqxmVNbxv/zYAJ82E33ztOzg+neC94ujojPMq57jKaCpDPllSPZpQ3jUcPz/HbEA3sDmUx2A2sHhtinKHaAumckzuVZhlhV6uhZgSch1qtZHi4LrGr9b9fIt36NkMvb+HX61aFmUburW2RxJRWQlh7bWWqegdvvZb/aQNaRvThvRadY1evkWjssBUjOLAoT+JsbDbUYg4IQo5M3lPsu59iP0/ni8K3g7UbYZ5rW7Jm3gdSU6NbpIn770YhXgM39R9zzEa8Hifw5pgrZFPEMOecaxpGZNpsXiWrJ0WJ91KDKZ30laV5UF8WW15gq0BHI6XSQ2cGLnBBN4PtVb7nmw/ssU3hMtvvHaFDYcY3rhdhIqt5GNiPHZ9336+4FzpNju9rIFY5g4SxvB4QyHSbtPEw7KJJxSTr9HA7KDCpsoEaWiwi8X3Q6sdnX5Xji/8mSh6DNsbpaLaF6ZpiAobkQ0XBxlVFOjpBPJCvIM8w08KXJnjco0rxCto5hl2oslWHh0Wi1w+kVHPweVCsjh9p8PNHBSOvStLFpmlyBqe33+IVo61zXn19JC/96Xvon5Usv9ixtk7HPqJNb/z9NNU1nBeF5xtCs7OS+rzAhpFcbDh1UeHaC31d2Vet1GzvbLi2vSMJyZn1M7w1OQxB2bF/XrB549v8OW7V5n80wX339OwfKbgmckjAG5OTjjKznnv9HVO7ZTjbMYfeVbuX6kbruWnbFzO2uU8rmc8rqfcubbHg6dmPLV/woPVjNPVhGnW4L2iagx3XpiS38tRFlxhyM5m5MsZ+aknX3p0A9pKWDJfWszKkp1uUJsarMN4j1pX4pmlRgra2jNAiCZhBedezVfSR9p8afT8B55Nmn+S3bqwYbtit+2iBmlRelwHLXpwPbZe2sfTSVXqXSnde0fbf3tsvdiGNLzWTxfsPF481nDsGWCnCvyuVETyXquordnes75hlmsN40xy7uHkpHeONLWQjBlvGQ7s5eEGE/J0/P0G8W1gvC64ETtmDHH73RRTv/15y3Dt2O7robL7/uzqwiLqwX7tS2Y6zbY0xr6VV4Keh3URMcQnK/QqNRAHTpGGSJJZXHqu3gBidLjUAbNR6aDdN2ChhVm7N0G7LhIAptOOBTjNcWWGnWTYqcbHGbf1kr8qlIQJlcKWiuXTiurQY0uhnl9990P2J2u08nzn/l1KLbPlJ4pTHjZz7m72WFc56sszrn4Frn3ymPsf2mf5zIxPr59BnWaYjUJvIF8pyhq8hvOnNXaj0Q2YjeJ47kF5VKN4eKXh1ekRedlgG8O1o1OenJ+wrEteunMN/cqUq5+taKYF9/0hf9d/gCuzFdcnZ5SzhjfqIx41c85twbX8jKNsyVxv0DiM8tTecJpPud8seHJyTH1o+PGDz/BqdZVb9SFrl+O8ovaG5TMl//j1d9I0mquLFctNwfmqwJ4U5A8NulboBvBQnBiypadYlpSPLbp2eAXZeYM526BPzsVY1bUsDhrCwC1jMS+ExLDZ9JYh6dPnu0FT9RZYlQmOLDrZ9eGuTi943maHAnxEWn6R5pvSvr2DAdjLN295EA58X7i4bVtKu2+3jefqq4lcSIdPDaT3XSRGBfZlqr+aTsYBlLxD/Xd+MC7G6xnkutO6wjerDbvIm31LpGSRt8lotYf2/k2mAP+K4uTkhIODA/5w9qfJVN4ruNwyOGk48a0omr3QI2++fcIM2tkp09lV2unSzhA6aBeO8FvHTmdDF1KF00vYxZ4MMXWVZ70XPobnYjjOrTdteEblQTjW2q2ZcDv7GpJJWkWLjqatsgy32bRhv3YxydjewEpy6w3mYB81n+HnU5prC+zEYAuNKxVNqXskB+UkHGhqTzXXVPuK1Q2FLTx25nn2fbdZNxmZdjy394jvXNzBoXhQLSh1zZktOa6nvHZ6yN1He9THJfkjw8EXYfrQYtaO8xtCmEBBcRq8Og/1TGNLcJmE5+SeyN9egzcxj6aS36QMIJJChKQBegPKeYpTz+L1ivsfnFAvwE4gOw+7a1hfd2TnCmUVduLxmQ/n8lx790OeWpzw1OyYh9WMg3zFYb7iWn7KmZ2wMGv+yPxzPLBzHtoFt5sDnsofUfuMpSt5vTpi7XIap8m04x/deRf3Hi9oNhnmdkm2VGQruefFiWf6wKFrT37WYJY13mjJqZ2v8Y+O2/dR5La09OtYrB0UUnosvBCOjJMWv960nngryGtMW6iujEHPp7jlSvpgoiTSUw+JyiWD0KAyomzizs9pCStvFlJPQ2Zh4ibepWu9r/Y4IZ+3XVM2yHun707w1OKaca6q28npFsN4R5viO769zbbXFHN6hBxz6yVHweE0IrKj/e19HHqsSapha6zd5QQAja/5Tf4Ox8fH7O/vb7f/LXCpjdeP6D9FFpdQH1aNQ9947UpADl3w1iuz/e2GxI5BR7loRtU7dmjDxdT5Hecf4mvpSIMO28s5JbTneP6t5C0k9R7bRI+tcGHcJhaq0g0W6cusyxLyHL9add6Xc+ijQ/Guipzm6gI3MTQT09VOZVDtKZSTQdxOFesrXpiAmcfuWcyiZj7bMCsrrJO6pTJrOF1LHdnBVDyu49WExw8WqHODXit0pdC1MADNOlyfI9DeffDmhMLujHh2ytN+j0fqhiu5XlsKixAlRlZZ+d0FMkj83gUGYTR0+ZkYs+IkGMc51HuB8ZiLkfSGwECUf1Ujx6kOPJMPPGZTZWweTll8KUNbsAUs31NBI89XzxtcraHRYBUUjtnBindcecQi3zDPKvayNU+Xj7lVHXBaT1jagvOmYNXkPF5NAThblaxPS9TKoFeK/FTzxCcbTOXaHGN55wwai5uV6LMVqm7k8/0HLdGGssSfn7d1aS17VAdSQ2CNRhJJW+AdkXpAznfGJAoYayl2b2XB0nzuoL+2ubWYX23JQrr/jqSEizzrVPMHk7ih6PXWuwLsosbvUsBpoyztdZv+e9kL0SWszsG527EhMZjDNg3LitKxbiiG3f49uFfp/XjTiQDfuPG63GFD7+jFmoe4KCS3wwC96f49Y7jtRr9lDPiCB7lFiW071cW1EReFHZTZ+pI21BePlybO3+R47f4XfR8Gh1bodsC63Enrz3NUISw2phOUDt7e1X3crMBOMs5vFC0bsJmJkXAF1AvAi7FqZg53rSYrhWTxxP4Zs7xiYmrWNufRespyU/DoZIZdZeAUJ9kMGo06N0wearIlZGswa8kJZhvJ9dhStdR05aTgWFnQNWgTvU7ASx2YcmJozIZgXCVs6TXCnBdbRFcgKn/qRoyLN8EAl5KX81pRPvbocE6I24ixiobLrMSTc1YYlKePZ6iHOQdf1czuOkwVvbxC1Do0eJ2hayWvi4Nm7lmfZHzueMp0f82kqFmUFbfn+xTahu6iuFousYXioFhRuYxqZlgfiJdWWcPJcsLxoz1pqxZDe/DVjPxMBsEi1+hNg6oadBohyTLYbMDYrTAyEFRRTMdcTFcmdr6T0voasKu/qwE78UIR5V1IiBC7zjF833v559ZgDUQTwnFx8d16kxBbOgZFUsVgrGvHhEHZQq9GjP5Es2UaQjLmDcZX70gXlG0nxm8WDhxO/ke24QDxplzorg5mKBfldpIVaVt2UvtzEj8n6ZQDra5e5XwsBE6ZeEqWlXdVMhsKS3fjQpI7Xfagbba6cFbXo93G7UKcPrZdaRcKKkN7/EBZIDIMB8zHXgGntaTLpLRqFc5BGRQzvG+ZYFGrUJUFajHHHcxx0xxXGup5xubQhBorOHtWoSswNayveJrDBjVryIqGw70VB5M1VydLpqbGesXaitd9e7nPV06usn44obifkZ8oFueIskUN2UasiPLyjL0WA2KCEobZeJTzNFNN+bhGrxpU7SDTQgwpDfkjcc28UbgiQ1dyj07ftWByv8ZsLHZi2BxlNIGW30zEIOmNGMJYF1YvVOuZKSeG2mcy8NuJCt+DLaGZeWxBm1PTlUTimrkcI1vC3m+XLF6z7H/xEW/8yJEYv8ozu+1ZXVfYCehaatUIHmCz8JT3NXv/PGd1raDO4IGBu9Ob1HseVzpQoKYWnTu0sdSrnGJW8+TRCX/oxpd4sjhGK8ff3P/XuDk/4SBfk2nLxz/3XvJXSg5fhM1hRr505GcN/sl9sjNhOarzdccULMtuAuQ8/mwpN6AtkUgMhetIHipOnLTqL4GThvSSvt1O3FombXgnbN9b8k3TGZlY6C8/tAzbVpB5GDKHkD+GNvdlCvkOhIAUpcF8f7UEaUMQqE7e5+TA7TjQ83QSun37/gJ+OOYN8tQ7Pbgh+SQaufT+9EpibJ9FvUt9Y4hRYYNwAzyky00DF8VY2++HRIkLqtvTZeXT/bbIHoOHMTRcve/iNumLFV8GSIqiXX9WpXQgbCTHSq4jXVMs9eaGSdxOibujvQNJODChJ7fXPZi5hRdOT8rtexbCPPpgDzWd4mcTKDPq/QnNPMNnSvJYmeR/NvuKeqGo9z3VcxtU5lDaM51WLCYb9osN16dnaOU4bwpePT3kjS9fIz825CcSvsvPYP/Ec3Xl0I0N8kwi66Qrh9406OVG1o1SSop36wa/qQKlO+s/Q+fwjUXNJhgn4rmtkoVzGK3xjQyoh7dK6SfekwElyOCzL0baZxpvxAh6HTwsE4zbVLM+0vBQvMxmLiHGdv7kQFcK1cg1mgrwYtRM6C5eQ3lfcn+bG3PW1z3VkzVm2rD/D6Zc/VyDyxR3/jVNdeAlFze1fPA7X+XTX36ayf2C9TXfGkbVhPBorZnc11QHGl0pZrcU9QKqw4KXTwte+52buMLjS4fZqzleTZiXFTfnp3zv86+yfi7n4YdmlHlNbQ2P1yXLFw+ZPCgpH0nebPHVPcyD0+4dqhv86Sn6YI+YJyPmvqIMVWA6tuvKRcPT9vW6M4S+826kTsx0bMWmbzi2wuERpmj3cZtNp9qR5UFYOOSJ0vdyaAzSgT8uyBnISz1B7CxdqSCZICfrg0UKPS1Jaod0VNbPbQ/Zv0p3OpLtOdOQn4+ScG9CskgIID0Fkl3b9mpt45jo+JdOlf8H/+Af8J/8J/8Jn/zkJ7l16xb/7X/73/KTP/mT7e/ee37+53+eX/3VX+XRo0d8+MMf5j/7z/4z3v/+97fbbDYbfvZnf5a/+Tf/JqvVih/90R/lr//1v84zzzzze7uKHuV924UGLg4htvu57gUIn3sMojc7RpytDIuhk+P2tx3smyQ5t6RnhmKkqtMc26mQAd0xdvy9qzMqrXpagOn3w/Z6Fxb7U1qEdWO9m/OiKJ5lqCLHHyyw8xI7y7CloZ4bbKmoZ4pmqoL349kciuGqjyyLgxXzssJoxxu3jljqCfdzx/HhhIcnM+pVjjrLOHjRUD72FGeiL5ifWPKTDapq2lvic4OyFtU4qBupX7IhRKXDgOKseKaBuu/rGpVH3cPwMmsl1zNNDHVQrPcNItMUVj+mqmXJl6IQ2b+lFiHfPBPDaTRea/w0x04y9EaDz4LCh8dUoYjaiE4iGlAhZxbHFpMYr/DIbQHrA4PaM5iNQq0NznjsVNFM5PmZDVQHSOF1rbl9todSsLqhqA8b/KkhQ9HMPC73YGB93cJ+gzvNUK8bNlc89mrN3pUl67uHUkhtNHXhWNYTzk3J2bpkb7rGKI9Snkw7plnNlek5r32n4/hkxvIkZ/pGRjXfY3Z/Sn7WoBovHtl6g5pNoKpxZ8tkwumlv7XPpBCpMT+QYHO6m2wF5mtkQraGa1hErVU7Ue3lhofvSaqsr9V2bjiecxebOb5PXUM7MYKkrw12aPfbGot2IQ0Fpu+tVl0mYgeTsPUQ2/O+1VgZI1zd2LZTaePrOebvAV+38Voul3zP93wP/96/9+/xp//0n976/Zd/+Zf5lV/5Ff7G3/gbvOc97+EXfuEX+PEf/3G+8IUvsBeWj/joRz/Kf//f//f8N//Nf8PVq1f5i3/xL/In/sSf4JOf/CTma4xjf10YUkzTEGNELHZO92l/2yYubBmo9LhbxjQagv6yEl1nNl2imX5nlfBiWJk2FjIaWdoihvFaKm0sfFYJ5Tf+nbykbdPSwkit2xVt20RspL2nq/i2eokehXgjLbtwPsPvz6kPp1RHBc1U00xEeskb8S5WN6A+kLYVjzWbaxb2avYPVlxbLDkqz3Fecfapm5K7MYpHN6ccvASTY5mtzV89QZ9XbR5EnZ3jjk9kbaXQdnPtSj8nEtXincNeO0B5j6qtzPbDc1ObCj+REJZaV/hpic8Nrszk31xIJPlZjT4LA+2mFs1EpVCbKoSJgvd6thRjWBa4u/dlm6JAPfWEtLvR5CcVzSLkpgBXatFGLDSbAwUoKIPRakOL4M4Du1HB+lqQm9JQPoBsabATQ7UHttToWr6v9zxsFJP7mscn12DfUb9nRZk3bPQUbzT2ag2VhsLxnufucH16xhcfXefk4XVufvAO33v1db5zdptfufMT5I8yzFpROwWnGWqjWauS83wPtPT728aj5g2Hh0v+1Dt/G43n2E75+6+9h3vPHZA/yFi8kpGdw/RBweLkHLeYoE9XcHLaLwxOcmNqNhVtTEuPRasMwqKLpSXTqYgL2xA1CUXT7XtiJB/rzs7Cq6zRmcLj27xR7P+qyFE2kbMqy+7YpltuBmPa4uytcSPkoCTs2aUhIgtzGN6L41YXKnTJcTqS1tCQtuUsenuVhjZVsYsctosUNmRtD77reZzDMewCVvTbgW+IbaiU6nle3nueeuopPvrRj/KX/tJfAsTLunHjBr/0S7/EX/gLf4Hj42OuX7/Of/1f/9f81E/9FABvvPEGzz77LL/xG7/BH/2jf/Qtz9uyDdVPkkVl8iFFM7rdSRFuu500dngxg88D5g5cTB9Nw5AJ3ZSgEpG2YWfyeNCJtjpi4tqnVNsexT4xXD0jlUjotLT3oCHYKtZDl3MbsK3iLLfVHXS+y2UB+tpV/GyCm09YPznDFQpnFOfXdZj5w+aKx80cvnCYuTADi8xineI7rtzneDPl1UeHrB5MyY4zikeKp/7RChWS3HrToFe1GJTjE2lbJkuZ0DTtoCYFz+GeTspuZj6dYq8d4GY5zdRQHWStschWnmxlMWuLOV6L+G5uqA8nNFMjNP2JRteeZqJoZuI1Tu87yseNeE2F0Pijgryy8l9xbykeX1Xj12sZ7AId2p+dw2aD22zQe4v2NzcXVp8K/bM+mlLv5zQzTTXXraxVM6M1WM3MC2tyJUSPyGRUXu691zC5p2im4oHFXFh16Kn3HdPbhuJE8mQn7wazlhCitkLRN2vF/kuwfFrRzL1Q9Y8q/CoDB+984Q4PlzNW65ymyiinNZvznOKrE3zm0RtFtobzm478mSXfdeMuP3rt87xv8hq5svx/Tt/Hr/3295O9UVLeV0weevJzT7ZyTO5tyB6vUCdL3PGJhG+VeLlutZbnG8JvKstQ0ynu/Lz1nFoKe/L+9DyOGI6squ13LtDJt8aB4VgCvXemtxBpYDXurLUcvnMxF5eWzUAX6k/JUfEdTmouoxFvlTaSdu+SqNtSwk+p8rtqunr59MHkXw0M1S7qfLqd9/9qsQ2/8pWvcPv2bX7iJ36i/a4sS374h3+YT3ziE/yFv/AX+OQnP0ld171tnnrqKT7wgQ/wiU984msyXj1cZIzCDdvV0b6mZGG7ffIgd6ljXLi7bxlNw467lf9qlTa2c1atJxTj1MN8ltKdZxfbnU6mnO8Ve0aGYGQiqbhkREKlbV8S58N/rlVWUGWJ3lvApMRnhubKAhuMwvqKkC98BqubinrPYecOs19R5pY8bygzy+F0hfOKu6cLfvv1p6mOS8rbGQf3FcWxZ3LckN89FYq1c9BY8Zysa40nTfCy4oudGVRZhLySaO9R5mAMdlayeWKKnYjnVC26mjFbCNsvW2kK59G1xRWGzVEu7MNcBn3lhFRiC7k+s9GyZAmiPu8yIVB4LYN+tva4QmM2M/TGis6g92C9aAxqIbLoXAbcWA+llysJNWYG6obsRKErSzbPKR4rXK5p5ppq0RkyU0mY0Wva+jO00P9VEGfwOrAmA0fHVJAtFcpp8lPIlqKbqCyUjyE/8RRLT/lIcm6TRw6vNK4Al2vOni3RjWz/1Zevo0MRd17DZr8QpmXmqZ+u8CtD8cDgS09dZbz08CpfevCDfMfV+7ywd5fvmt7iX3/3V3n1iUPuHy/YvDSnfKwpHis2BzPy5YTidJ/yjT3YVKiqxnOOCuos5HmYwOluAuO7uq2oQxprwNBaBnilW7WXIeu3XeE5enHDSeFwUI7vK11YMo4BuwwHsIMMljIgO4PR7WPbgu7IXoz5PJ+ERXd5O1sqJO01bIf2tgxXa3DSkONgsu9df/t4fqXZEmf4V5FtePu2aLHduHGj9/2NGzd4+eWX222KouDo6Ghrm7j/EJvNhk1MdCKeF0BH2BggDd9dqFCZbLsLqSFJyRfDh3TRMbzbeerOmA4MYtpuZ/sEkhCqa5cJSTy/IXuqFzaAbamZWKcSl0Zvc2i+/+JCWBQx3IdQJqAWc/zVQ5qDCXaSUR1kgWKuwnIgUn+0frJmcmXNU/tnlFmDDs+p8ZrSNDxeTzm7P2f6cs6Ve57FG5bJvTX6vEKdb1Bn5/jzVTejnoV82mzaEirYbGTgysTLdXtTfC6SUfq8ain49SJjfdXgMgWe4LWIB+UDccQWCt3k6MrgCs36UOMzhAlZ0hYryz2Ly6VodOOpFqLq4TPE0FnIl4pmkqPrDFOD2TjyM0t2GsKNkxIo8WWBm4kwrjrfoJYrEaef5GJ4VhVmXWOWmSyKqRTucE69V2CnmmrPtLVwm0MVrseLJ7hRZKvOqErHkOejXCiUrpTIasX0nxXDNbtvKU4aJvclv+MVzLzHazGULjOdsXtUkJ96YTMC1YGmnksN2lM3H3GyLjllD3NQ4a3i7N6cvS/k/O71fX7nyaf56e/d8EeufB6uwK3qkF/nD7K8N6WZGuzEY1aG/MxwsDhgcq8iO16h43sTQ9phcuXtmyzDoXS71lhkC0ZKfvteRVKHMfJbYrg6UlTC8kuO3fOK4nuT1E728lv0IzlbebNh/VTL+kuvJzE2zuLTdd7oG6zhfWjHi/Q7ORg425E+QtqjRTo27SRnpGHDbozr2NZvwkL8OvFNYRuqwWCe6tZdhDfb5hd/8Rf5+Z//+V0n6gzKRZZ9eKOT3E17mCR81ts2bhdmZzGOOyQ+9DpUOF+vkC+htra0c9vvWF19RbyGJCSRZd3+CXMoDYG09F6lpSMn6h3tZSVFha3SRawpcRUqL1r1AW9t22f1tSv4SYmf5BJOmxjsRGb/9VxhJxLG2hx5XBC83b9xxsF0zaLYcFiseGN5wL3TOetX9pi/ppne87z71Q3Z2Rq93EhY6NFjuT9liT/cF/Hdxsrgeb6GZo2az3AH+/gyx5ayWKSuLDSO9c0ZPhO23OQN6QfeKFbXMtZXFCjQFW3Br6l9qzTfTKGZ5DK457A5VG2Rsc2FWq4CXd1swJWwKaRfOEOrqqGshOvsBJZzJQrxayhO5Hi6yXA3D7pn6zw+15jzBv3oDF/X0Fj0eiMGuhZxYjWdSIgrz9F5RlE1YD3z87Xk/jIjuo+zIuTpDKfPlCyf1DQzuY5m5qkVbI5CbZqlJYKsryrqmXhdrvAsbxoef0fWGW0v3potwE49+alcJ0B+5rETYSOipNg6P4XZHag+f4PF2nO4drz2oyXsNehpgy1zJvcU3Jvw/3j9h8Wr3bMcPXXMe2/eYfJMTaYcP3j4Ii+tn+Czx0/yuc89w+zVKdN7E+a395m9doY+XuIfn3SCz1mGT6TT9HTa0ua9DcvCxHXKYogtKupHbkhVg0/WnVNeIhTxowmU0DR60tSSzzQyefIxT5284+14kowVKs96LMr0XZX97fYxLqChR1UbPZ32dCV7S6ckKYatxTp70aAuqpOmEnpqRu29oL+fdy0LM56zbUPqBHyDDtjbarxu3rwJiHf15JNPtt/fvXu39cZu3rxJVVU8evSo533dvXuXj3zkIzuP+3M/93P8zM/8TPv55OSEZ599Vj6kntAQF+SxtrYdus9x30FYIKXk9nTTYucb5sKUBp/EnwcKF73TBZmW1mNL2pqqT/c9rKTj9CrvE8M4CHekM0flQ3K5DacEg9s0qPlcwnCTgvr6Pi5INSnrqfcM1UKzOZKiXhcGd3ujophVzCYV1+dLKme4fz7nc19+ivxOzuSB4olbjsnDmvy4Irt3IjkhIC4aiXWwWsuMuggrHM+n+MOFGAqlqK9MJM+UKXTtAckj1YtAcmkUbpZjJ4ZmFmewnVJFKzOlxBCZtReauIemBJ8pTCXeijVgJx6XgXHisShHW+zrcgnV+Vw8HlG/UL0iY1uKmr2pNMplmLUjO6+FMAL4RksI89oBZOGd8B5z66HU+3iPX63DoLuRfFgIj/lIbc5zGXvnJfq8wpw4Dpc1izcKyfPtGVZXNa6kLSaO/26uKGxOG2p0mWrvkyvAm3bYDgXcMhGwBVCG9clCaNIVoKySe1oTCqTBa8X0DYMrDN546n0PJ6qtX8uWYNeGR3qfzDj2yg3zvOKl9RMsbclhseK9732N8+8ouHc6Z/W/HTC/esD04YLprT3M6/dFVqppMJMSX9W49aY3iCutOtmopMjZp6UyLTmiU3Jv1z1LvaZ08hhD7NHjGrAGU8X7/goXrif3diFjb5hH2oXUu6kT+v0uhnEb/rs4KjXMh+1S9fFusCaaShbbbOKCtOyILr09ocO31Xg9//zz3Lx5k49//ON83/d9HwBVVfFbv/Vb/NIv/RIAH/rQh8jznI9//OP8O//OvwPArVu3+MxnPsMv//Iv7zxuWZaUsQB2iCETJnhJwG5jdVGMdyiJcuGsye04rukenHrzTrHTcIYwgcfKrrs6aGADXqSIka7vtbNmJbZrVzw8qaMRb1aj9ua42QS7V8p6WFMRv81WjvWBpjpUbA496GC89i2HR0sOZysOijWPN1MeLGecPZ6y+ELB3suO2Z0N+aMVal0Ls2+5wi2XqLJExbqwqoKNk9qqyQRfFhKinGZhkUhHdZDJAKulENkb8Z5cJotLoqCZZzQzjS3is0IG3LwbZH3mwYtEFCpoBWYS+sTThkBdKdv6WsKOUaYJBxRiuOwkUMydEg1EZGD2yO/NDOpKoZwhNwqzsaiNFTXw8HzdLKdeSM2ZahyTx6X8HvtjyEH69Vpo5C7IIiW1fqpxcn/P1+gHjymVopyUTK4fkG2m1DNNPZVrjNdaB/KH8v3r9koMl9fyfbtidKwxS7zNKJVlJx67UeAVynsRitBC4ilO43NQnD0noU1vQy6uEqPoHmU8WsxZzzJOc3nnJ6ZmYmr+wNGrPFc+4NhO+S9Wf4jqaMLqXsZBMWevtujjJUSGJ6BigXNKvkpqIXWg3nufLNkTCR7RM0nU2ne+e5G81E5aLSqdVLbGTYMfqMM7Sy8MKQ3ovJOw3U690jdBKgUVr6dbVyzJjcd2pG0FGC4plbYtQb9dPuwXoj89sYi39hp/L/i6jdfZ2Rlf+tKX2s9f+cpX+NSnPsWVK1d47rnn+OhHP8rHPvYxXnjhBV544QU+9rGPMZvN+LN/9s8CcHBwwJ//83+ev/gX/yJXr17lypUr/OzP/iwf/OAH+bEf+7GvrzGRht6G/bbjxj2XeZdGmApqF5uQK4rr4kQiRCKGmypn9JYJCSG6VJU6Vsunv2+1rQ1V2j6FPhUKRYoj437tIQKbsTU4bSJ5kAuD9rfIoGpDGyGfhNZSEzWbouYz7JV9ljdnuFIGnXzpsLlifaion8tYPmPhoMZXBjJHVlquHyx51+EDKmu4tdzn9LduMLvluXqvobx/SnbrEf70FK5flVCgUqi9ueStwrP0ezO8XkCmsbOczSzDTgz1Qjw+CVOZlnrvtdSNtcSFtYR3ak/IN0n/cLkQKKxXLZnBTjx24fBG08yDAsWa1kOrDjx27vC5g8LBymA2MqCYoNjhjQoDuJf1wRYWVVjsxuAfZWTnqjWaXssiks1MUc8103uGyeOS2RtrUAq9rslvnZJNS9ysoJnnVM8coZoDIT9oha7F4OnzDbpu2mLWqA8I4D97Dx8Yonoxh+lEhHPvPma+qWn2J6yvlyxeOkbfe4w7PuHxn/xuqbebK9bXupwZ0Go/5qdigE0F2bnoPtpDaKae4ljFrteGIe1EVEB0E8Kuc4/XnnypyM/g4EXwqgvVra8EJZAG7OtTzooJp6Xj4d6Cm1ePeW7vEb/xyvt47uAx79u/xd/7of8b/8v5e/i7d76HL/7jd+KyA2Z3phS3Ctwbd6Tts5l4TZG2nghH4/uLZqqypC2MjvcyMAGHNZT9CW0gRCW/Sc1kOI6ztMNsOilOGdGxbi14hEI6ES8trhnW1nZe5H215I1dtaIZ7erlQYwb2F6JOd4fr7pi7MiabuW5zNb4h9K9BXNjeqKnlZqyGiMh5Rt0vr5uqvxv/uZv8of/8B/e+v6nf/qn+Rt/42+0Rcr/5X/5X/aKlD/wgQ+0267Xa/7D//A/5Nd//dd7RcptKPAt0FLl+ZMizDuUhNr190WfodeptlSchx0lfQDDjrgr75YYrZ6ixa7ZVOt2b2PXtvE4cXbXrkScHCd26Gh0dVn26mX0/h7Mpri9KXZR0swzqj3TKaIDx8/rQJGG5mpNsZDQ4LysmOcVqybn1oMDmmVO9jBj9obi6MWayd0V5n4g12hh0/nHJzJAlCUc7eMnOW6SY0OYT0J64r3Uc/H2tA3ekiFQ08MtcCEHUwqpIj8VL0yW7/DkK2HQxf2aiUgz2VLyNnaShPpsyHEFQ+NKj5s4yGS1Y3+ekZ2Kqkd+GrYzyDH3xdCxV+NXGcoqmUc5GbxVrchPJRSpm2BMz8QIZhvP7G5DdlqTPT4X2aTGyox/Urb9yO3P8MZApmnmwUNDFpYsb5+191ifnMNqLSUawQPx3kso9pmb2P0JzSxHJwXpqnLodYPynurKlPMbuaiezBSbqxIy1bVq83kx/9USQVTHcHRG1DqiEYsakFFwOAoXZ6FOLXp00hBaxmT8rpl7mqs1s6MVT+yfUVsTVgp4yI3ylI3LeGV5hd/+/HPMXs45+oJlejeQOh6d4R4fy70M98dXVVeAHIkYwcPaEv+FLiS4I6zXKrKnorfRAKT1XMl2nYHo11Nuve/BsAzz8S25BPqrOCST3y0PMaHix7zY1pjhk8l52EdOuGM16q0Uy7ZntUW3bxcT7cbg39+q8tF4pYirH+/CsNDuzZiGOyiw/ZDjBa5wCAe0xx8axl2hhx0ufI8plL44Q+OZhCt7q6a2hx4Yr+mUGBrU8xl+f4Hbm1AdTbBTQzMRz8CFQcZrePTdDl86VGHZO1ixmGyY5TXTrGbV5Nw+2WP1pQOm9xTTO579lzfkD88lmX62RE0mkrvSCu4+gCKX2qsnDqgPJtiJppnqNhSIEk+pngoFXYqVwRkR6nWZGDjlPc00fGegOOkGPbPx5EshZQCBFi/eRbMQo2NnnmbhQv5KBlwfjJLPHRgvihTBeJmlJjvTcp5ovGZSdO2mFrNosMc5yikJSWqPqjR6pcnPQu1ULP/ZdOG2vTcaykc12YMV+lEgH1Q1TCfdYHq4J4tx5oZmr+T8yVLuTe2Z3gl5sUxj1o0UUAdmogqG0K/WcO0IV2RiZMoMV0rh9eTLD2ShSe9x1w7YXJ9R72fUM8X6isZOOraly8BnnuxMtddQHYR7pj3aCrU+6jPqWgyYWXuqfRUmDJJb07Ucs54HY1bL/WnmgAt/T6W4utl3zJ8+Da+VZ5I3PLP3mINizdxUfOn0Gi/dvo5+acrVz3im92uKByvU6/fkfQw5KbfZ9A1ULOKNxnyL9dcVJe9cNWGXZwadYUmFALzrqXekNWipMQW6XN1wTEjz5kkY9KLcVHrsXo1XOFZrvNJzvZlx2vX7DvzLMF6XW9swzW/t/E33DVk0SkPJpfT33jHexGhFIxFd8M0m8eQGObdw7Iu8p6HHJTOtvgHqhQtUEPKtKmLtSrv0w9ZMLpW9CS6L1qjJhPrdT8qaWROhXMuaU8KeWz6jaKYeO/UcveMRk1wkkaZ5zZOzY3Ll+PzjJ7j9uSdYvKJ5x+9sKO4t0cdL3MPHYrBmE7h2RcJYZyuoKtS1K9Q3Dmj2cuqFkfBTEObVDS1zzxadRJItuyVRXCGelcuFKLC5IvdSNwrlxLtRjewTV1XWtSdbi5eTbRTLXMMEXCbrYoXbhGqU3PbMw9TK8iEg4Y3MSQF2KfcohgObhcPtN5hJg1Yeq2UQJwvGr9YoC/XCk63Ab0KoKKYfFGz2jLTxsZJ6tWKBzzMhs0SvoW7gfI2ylvy1moO7R/hZiZ3LM7WlwU41q+s5yk/bkIwYEI9ZW4oHa/TZCh4do6taJhFliT89wz9zk+rGgmo/I1taJg8qyoeKK//kEZQFZ99xwMk7ZHVqOwlLxaxlcrB+InhUDvQ57bIyElql9dSylUhgeR2MmxWW4uaGxT3SFCeK8li+07V40tkKJg8ANJtXD1k+3zC7vsRnis+8/hTWarT2/OXv+595+rlHPPjQgl++/1M0k4L8as6+9+jHZ/jleX9l54TW7lKPKL5/KtZCJqtEx3xwWHqlWx4l0OirugvFJeK1LYaTyoSk1a5BFj25Ns9p+4St7gD4qmMitgXPhKhOZAUmEaE2/xU1GZNi45TF/Kbo8Qe6iFOveBn6qZK3chZ+j7jcxgu2b4x3/RqpHrsnEjOGpImE6NEjgAyMVmQIBRZfj4F0Qa2XxIPz/ndD8dukc6XHB7olwAfMI19Vbc0K9GeBbRFiOF9r0JxH7c/xN66yuTFndS0ktr0MJMsbhs0VWD1TYxYNJrOUucVozyKvOChXnNUl//DzL1C8XrB4FZ57uaG8f4a5/SjU3Cj0wb4oSTgn9VqbDf6JqzRH11hfK1rtPpdLTq1VipjQtccBGe1aWLZQLfstitM2M48rvHgS3uO1JltK7ipfysDpMgIrMAjOWh8YbuDPFXYGZB6vPLrJaAqHzxzKxCXkQ5tyWU24zjxeG6I6u505lHGyBIr2UMoz1ZnDLXNZT0sjxAelJH+lxJPRRrwNYWyGvtdYfLWWSVdR4Bcz/KykvjJFV9KHvdGYszAQO091VBDp7MpDtnTk5w161VDvF7hCZvTL5xfAArO5ileKbCV1Z+Z0DkB+75zsscHuF1T7OSfvyCievUlx5pje3TB/6USupcg4fdeiJclMb0t9WRRfj55wJHPERTibmWyjnDwfvHij86+Y4FnD8kk5lq7ldyGW0BZZH/xuhssPePC85eDZY2Zlxdm65Jd/5yc42jvn/VduU/3gKScnJeZhjnL7zG6VZPdLeOMOejYD73DLldRzZVm3tlcMxRemVzPWYxUmebCW2KEUbrUm0s97JSkxd9SSNrp3s+ddWbedI0pzSeFdTtUz0tRBW0wdx5EhezIZX9rxyHfn3CJjxHBlOubFcSYeqxUSTYqXd5Umqf5nZaKh4xvC5TdeuzBMag4p5G+GNHeV7js8PrQGbOdvu9oTwwYgMy71NTy9ncnZ/jni8gqQdPzhYUL9FlcOaK5OqQ4ymql4JcpDM9GcPetprjbMrpxjjKPMLNO8JjeWZV3wcDXjwYMFsxdLFq969l9Zkz1YodabVjsOY0QtwjnJMUxLmE1ojmZUhzm21K0ahMtVt/JwGAh141E1XccOocu4ZIjLaT0vb5Bym6Cj5ytRTVdN4sWGQd0ZIOvOF/8leD9oL+3KPeReDFHm5ABeSQgwc3jtaTyS1wLInZzbK7xTXX28i1bPtyy9eC2tyG7YJNt4WdAyzuxNKOmeTnCHc6qDguowCzknjy002bnUpDVTLQXT0Hqn4ajkEFabliVeOnFkg1eKfCJh2TzTIsXlpC84oxMmp7Rbr2tRBgme4LzMcIXGGcX0fgj75uKR1nMlUlrzYMBcmIzQdXkrNdrgxSj54KXZ8HwjIzSurxbvndmIGsjkjuFxucdyb8N8WpHnllWV87uPbrA3W3Pz8ASeg1urpzgqJiwUFOuNTA42m/AuxslbP28V3ztZ38oSiVhKZTi7Qy4qVdS4IGfdvYjJJDiVdbuIEb21b701JuyUnmonszvGqB1403Hszc63Y3zaEhLeEWn6msa+t8C3j/HaoWso3yfkiaEX1uakBnHpNEZsdxwnQsUH5el5gL2/+zUVOpMBCuV6RqYNFUTPKs7C0mRpbIf8IP9GRQHvhXJ+AeFEFQXq6IDVswfUexn1VIgLykoYbvmkYv/993l2/5iH6xnLKmea1zwxO6XQln/xxjM0X1lw9fOw91pFeWeJeuM+aj7F5xl+by5tsE7EbtfrYChl8G3mktPStceHUKGNspSZamWNsnMl62tFeS8dRX3FgImXIt6WrEwcvKOw8qPPaEN7weaExR+F6BELqpu5p174sIEcw00dTCymcCjlUcbhnMZWWoqhM482DY3x+EqDU6hCWFPOKrzXeKvAhYJW5aU9XmHWYfYbvK0YVsNDeezITxtRnC9zCScZjT2cs7o5ZXXF0EzDvdJBxSTXYaHOEIoL98CsFNWZIV9qspVh8eqa/NEKqpqyFNmrai/0MRNWqy50a/R0yBHq2rP3WoPXiuxc5K3c3jRQ8SuyL7zavnfu5Azz1A38bIJabbDXD6iOSs6fyFhdF2Hg/Ew8z7iydDMXxidA+TAQW5wY9uiB2yLoNjaSj6z2ZQaQnSvmr3uKxznr6xmb9zl+6LmX+PLpNb70lRvMr6z40899ij9/+Ck+Ov83+afFe/Fqwp65Rn73DPXYtQoagOQE01Bh711MGcqdp5OG+aJ342PIL3l/tybCxuBr3xmu4L1tsQCTcaBV/dB6iyG4K5/ercisg7Bw3Y13ptj23nw3+e0O2405qQbjsDj7IqQs7a1ols6kxvRNKoq+Flxuwob6SbLU/irVG7wjNbwd4C+gqvawi02za/uU0TeImUPiog9Edns5szTOnOTQWjFfpfuGKD3ecE0y2FKSlrY5zLNP4RYT3KygOiiwE0090zx8vwyq3oD9riXPXn/EXr6hcgbnFRubsawKHn32GgdfhKPPr8jvnYmn5bwMVlUts3HrJGw4nWAPF9RHQsRwhQjX2lw8q+g9xXBctR8MV+mZ3BPDpevgRSgxRu02ObjCtyEllBggX4TclQe90qKxdyJCtdnKUx57odQH41UvAhX+IBRiacSaaCQEaDwmE/ZGNF6he4mhcyq55w4XcmOmtNjTHKzk37zx6I0WwxUGZt0E4kYtXkT52LP32gazalC1xTw4xZcF9mDKybvn4sVMOy/Gq8Dgs2Ls7dQLUzIw+lTSdXUTNApPPfNbNcXDFfXhhEfvKcnPZRHObO0pTmpUyHcev2tCPVethJRZe4ozz/yNimwZnrUDfXoeJmGq6wNK4WcT7L4QTczZBrs/QdUWfV7JMjWN9BW3P2X5zIz1kWZ1XSYUKI+uOkOGIxQ9E1Z/lsU3dS0kDxW8tuLE8+h9nvKpJe+/eYtP/u7zoKHY3/B/+dDf4sXNTX7r4Qt8/n94D3uvOKYPGsrbZ6g37uFXa8nPDMkYQfmiXdTyAlLDtsHov+vpqgy9FRrSUF/y20UCvvF9jrntdrxIx5w4DoUxpG3vgLCxc6mjZLLcXtcOIllv/IwvxQXcgPZYSf4tFRP//U3Y2IH04YvEUVfs1/uXHQ8GBt5WYrCSxOTwPMPP0ql2TCuGdVqJ4YrHaNfKki+2Qhk9keCBoRUD7VE6a2vAVFlir+5hJyHMU2iqPVkEsbrSQOnQpeXq/jnTrEYrmV29+uiQ84czijsZV74Ie69uyO+cCCsNJDQYQyTOi1DuYobbm1FfCYrsuSy6KKxBiGoLLuavDNgpbV2RDO594oYzHTkC5XuDMwTPsb0n4Asv40fw2FymguEUD89lYMtg7BRCqrAKrJZ6roQDpHSYNXppg/eEF1C8NaW8hAeD4oQKbSCQNlRYSDLmonQTmHguSCgtPcVZePZaoYIxwHtU7dC2G7ijZyQ1X3SsSNX34lrquQ6PZS7ea77KyB8pzLqhPJYcmTdCh/c6Jz+1mHXD/ssbNlfyIP0lz2qzD86UlKdZYBJ6uDkLuUlPdhZWn7Y2rKPmoZFIhV6JkohabVCr2G8V+vicufeUjwrKk5zz65pm1pVB+MH4qhzoDa0YcLYKkyDEq57eVlSrBZ88fSdmr8Yuc6pHE371jT/EBw/e4HsPXuPL/8ZV7t44YvZGwdV8j9m6Rj06wT8+FnHkupZ+7IJUnQqKHDsms21NVTRadiAwED2nlqg1GA+SYmkJTyYGI32vWw/M9Ty8nemEAUGsVbNI2ry9Xee5XehRDb9/K38nzeFDb5J9oe7k7wHfHsYrZbX4xCPx2+K4nbdEzxgNNgqdKAlDpp1SK7AVW6uYxtCiMf2477CDxJlXyn6K7XUDA5kSTHpvs+7O0SsN6Fx9NZ3i9xdUR6XkmoLsz+ZQc/6kJz/a8I4nHnJ9csaD9ZxZVlHZjOPNhNVre+x/VXPldyumr50Godw1lAUUuSif92LfQTD2oGRzFAoiA3OxmcpAGUkFtgj5jOBxxQFYpJXkX4LhcTldeNwHY5A+Kot4OV4Mio/NSgZ4W9IaSwkrIrktFWjwjQlGMB5UDJY2Tm6tRwyUkzaQNSjtUQpcLeFDdGdA0R6MR59lkn9T8lhUA6amVWkvjy26dnKfSiODeiEK6XpTky8tzhh81r92rwm5vq65LbswGrDQlnjt6wPNdJqhK8v0fs3mMJO11kolGpEWsvOa4rOvkt+4Sn1txtkzBZsDhZ2Kt1rPjXiMNVQLoenrCspTQ3buRDWkdpi1NNRNitA1wo1trKx9ZgyqqjG3HmKco3htSv7uq6yvZKyuSTg05rmi4YdI4uiMf70QD7E6gNkdz/Qe2NcKmh89Z9lo1MOCT/32uzh934Qfe+LzfOx9/x3/9ys/yD9/+TmO11Oy5QGF96jTU2HHqoSlFyZ/fpNqHA48jOAxYQyuDcUNojCpxFLjtrRJu1BjP8LSsgCTerHobQ3LaGSXxKNKVS92lOuk52nDpbmSTrVr+ZZdtbEDtJP+ASV/2M63S1Eevh2MV1rXNfCOgO7hpB0lxLO3vKg0idoK2PY7lY/9zPskTh47RL8AUfYPP6VswUhzHXau2KZYfxGvq33grs9cBGlMomuGCsK673yaZl6E5LcsA7K6pikfe9ZXwD675sfe/UW+enqVl0+PeHbvMQBfuPsEe//jgufuNEzuL0Vf7+QUZ62Eia4ciAq6EeV2X+T4/Rnrm3MxYEFyp5oLy8ir4EkhIrjNPCbiPXbmW+KDV1DvAVphVkFNI5IqkAFfOzE+8kWYnUNbZOwLB5USg+EQCScPzVRqxbQV8l9zpUaXVozPudDkfPTAgkOW5Za6ynBWdR5aMGAmd+LkWAUb3RqnZpmL1WgU+sxIuDB4jdl50PFbw8FXGnTtcLni9JlS6pusx1SefC8nP60xp2uKhxVelaA02UrWE7OFhNhiOE1XgekXy4ri/fESUtRWJiyrGwpvZkweO2ZvrMkKjXIaU0P5sMYEhRn33BOoxpE/POfwdCNLuSiFn+Zsrk7a88zuxsmF1NtVexr2DaZy6DrHKxFszlYOvXGY9RSzqtFnG9T5WuS/Msk7qbph9pk3mDYNR6s1/l3P0OyV1HsZyxtCLHKlPM/qQPpOfibKH9kZZBpW16QfaQuzv31A87xi/fwGnOKlzzzNSzzN7NlT/k/f9Zv8iWu/za/d+AivPfE0i1ducPCVIyZfuC06knEg18lkNUZIXNXS1tM1+BR0ob2wnwtrycX3MS7Y2kpFYfsitzGklqYEIqs5FhaboheW9HVFTwg8zZdHIkgYS7aEdQfhvlZlf3BtLbRhK6QY2ds+LFAbjxXGx/453v7s1OU3XqmHFOSitm58SuVs99nhdl+0fdwn/XfAStxdHNh/gF1Yb5Cb02HWE46jlG+vS2V5l3BNQhiRqtup1FswRhQ0nrlJfVDSTKQIdXOgaaYyiJ09o9hcs0ymNSub41DU1vC7925w9so+89cMizcqJq+foo7P8CenqP09mWEqhSulyDXCHkxlpWEtg3xcXsRFRZzEI1C+y9tIviLWcon31cwkdxNDa/F9aKEYMOrCbVbyW9wmql9EHULlfVcnVoLKJa8FSE2XC6HByFr0irrKsE0kYNDVfOW+jWKigYmV8CLgrRYPy2vJ3VSqu34npIX8TIypDZ7P5ooYOJFh8qyPNMWpYfIww6wsuvHk5/LMda1xmac4FU/IlqolcqTelzeIFmMWulHwVpqZYmM1xSJHW4/zXiYbWoVQp2rDZViPPtvgZiVumlHv5VT7Rm6T9S2xQ3lPU4oSitfQlKYV6fUGzEyYjMrl5OcF2fmU7KwmO173mNJxKRg/neAKg1nV5A+WFI+muNJgS835EznKqlDDFxiLwTuLxd+xjGJ6z5OtSs7eU+MnFqzi/LUFf635Izx79TE/ceNz/E/fr3n55nWaWckT6+tk96eY41Pc6RnUNc77EGUJ76gpuvffGOJKyG2BcxEU4tsFaAd5sOGYkxLIhimBtnN3v6m0ZjPdP92W1PgMakUHaAWIh55gDEumJLVBVKg7yG5PbIu13bumt8eQXX7jtQu73NxB59lybXdtH491EbEjni5Nbqa/DfeLxrWtrB+wAqNhSo1v2lnUkHmoUEryWx7QZYnaW7C+uSdGZKLZ7BvsRMbmbOU5e6eHw5oyb6hcxqbJWK4LVq8vuPopzeKNmvLOEu7cx20qScTPp7LkhlG9a/Ja4wpZ/0r5hJCRxQQQ3QAVB9cY8XAKXXnczLfqDHbqg8ZgFLelrYtqKe2R8KQS46Zo6fLSro7iHQ2XC0zFZuJRxqPDwOMy1xooZWIeCzyqZQ7ixJvzme/o80q2zUJdl0dYhT7kx3TI38UboGtRkSiWjs2eptoXL7SeS7t1rUKOUIybMxmze6CcF0/UCp3eaxEfzjaGzV5QdE8MZMu4DHk+MTKqHdRVo6jnhuKkafNxUm+XSf5qGUSDnUNtKtzVOdVhwepqJqSKaGg3vpWLqueqVakXtXnVTnBkoi8Ppp4q8pkmmxsmWqEbJ/kx79GNlXXZlBiv7KyCe4/Ij8+k75UFPrtCvtKttuXqqoQYCd597A/NTFE+8szuWZbPanzphMDxyKAe7PGlpyf8uaf/MX/mmX/Gf5d9L186fo7p/QnTqaGcFkKdPz2Tovosw7c1ThpXhYVhlerWu0vffR1D2Cq8sgrv+2SI9nVO6OxbUaAdk+vdyu6+93sqDt6bCPd2TNqReIIk5QGtmG+/AfhBrdquUOqOhm9v9zbgchuvXnI03JR0sTSXMAyTfFi35HaiH5bQSYcMwS1dMOjWz4LtB5I8rJ4kS6Id1p4P2pi3ynL0JJNlzMPMpY25Ry9s4FVKItdjjg7xVw+pjkSbbvHqGp/lHL8AR5/3LF5ZU7z6gNM/fMRitsFoT6Ebbj04QH95yrv+fifp5O7cwzUN+vAAblzDzQpU1bRq8PbaPnaewyQjf7AErVk/vUe1kGJT5TzZOqhk5KArZNBDRFzrRRxYFboAazw+9zS5BS/5p+n9gUcVjZ+WsBG6s4XeeCFbeKC0+EzhT0PdUSBTVIdQ7znc1ToQKzx5LqNvvZJiYg94r4PyhUfnTpYrqXVnhRN3UClPlluqKsPVWsgblUbVwVtLxprpfVnW3hlYXReZpDQE6nJPFQhXLlM0U422GeWjhvy0lvv3WELNrsyYvlFRX5nyWJcSMoseiAWrg1Dw3KJcRlSK14GluDnQlI88k/trygeKB989a4VxZ7dy5ncdk7sbiruPaBY5Z09mnLyQdDoH+Vn3AFzeecNpTVcsLI4yUa6BWotnnp1nlA836PMgSzUr8aXBTiQv541CXT/C5QavNWiYvnyKuvMAv1zK8jlPXKU5mrF8esLJOyQ3qKyETpsZaKu48tuKZi6lBtWRp7yvmLyW8wuf+uP829/5OxTGYvcb7vwbmuJBwfRuybVPl+RvHKMeHYusVhve6xaudFUt+UmjAC3rhVW1iCQPasC6vFLWKfG0jEMZZ1Q5C6QPJ7mxJK+lckVPEirJS6VyVNFQdWtnybFSZmBcG7AdgxKVDXTW55XEcTV1BuL4umUQ4zibbN+Oj552fB5zXgIp7hvOBJLBJa4W7BLjRpzBdLmwmAiNv/VrNFy7fa/qXDbeblTsCCFufWH4sa0vU8nnMOspy20lexi0S9qqC42aTnHXjrAHE5pFjjfw+IUp1YGiXjjuf7fi8XfMyM9maH3K0WzFUXnOP/rCCyx+p+ToxYby5Qew3uCdQy3m6L0Fflripjn6+Fzo0HUjkkLrhqy26PvHQt6YFGSnNepIQmGRBRZJGDq8H94DG49qgocxS+8LKK+wU8fGKLSV+iCCo6Nt9wRNpXCZl97rIbIB0fFvhS099QLURO7v5sjhZ1aUL2qNbzRNlXWGKfPo0spvHrIi5LVCvNPPXUujt6HGC6BWuTTMKlSt0WtZgDIWJSsbvK61CA1Xe4rqwOPzxDj7boBXTaCKe2gmijzXeKPBe9TKCXOvtqh1Tf5IsXjNUM9zmqnkwQjjlq4VziuaA4udKfJjGSxdIaUHZ88U6LqQ88xE/FitQmhxX6NsQX5nTrVvgmI/rVpGXN+rK/b2baiQ+KoFzziPgseIR6ms6E76lqkqdWO6sbAxqDqn2StxhUFNc5kc5QZvMprDCbk9RM8m+EI6WfbonIMHS/a+OmV9fcLZkxn1IniahWJ9PXhADex9GdZXpdzCvTrnb7vvZTFf86533+HJ2Qm3zvd5/eEB99QeB3s509enmNsP8OtC3kfvUcgiZQqZOEbChm+NmdlaiDLmvGQJm0inTElcQhRp5Z2KrharrTuLr0ndDf69GtBUQxE6Yoi1W+fsaSKqkLMNx2jHmp4HOBhf03Gv93dMk6i2fQCehGQCPRmpbwSX2njtREqM2FWzldZZJQbrTSvj22MkMeY3i/W2+4UZx5A6esExYlw7hiqizNNQUDP9W01K1P6C+nCCnWXCHisU5zcU1aHHX6nxhaX2io1VXJuvcV5xe7nP5EUxXPMvH0uYhGDw9/dwswlkWopSz9dtx/RFLmtM1Q5/eoY62Afr0FUj6hhe4QrxPHTTLS+fUrlNFUJ5ZaCOGyWzSwU+99jcU+2pluTQ3q6Y70qO1RYotzeR1tOwE+Ql1eBnFlWG/JQLIcG4vxH1DGPE05J76/DWEKnwumi693ZjQm5LiXGLY4YNhqtGFmwMuRizpmVd1gsxMrHQOsol6VpBWrwcQ4AGfCZWzk5zdB76oNb4PBAkgrGLuT4RGQ73JHqiZ6EPKrkvm4OgqkEIJ1rxzFwhRcLNROMWU5pStR5NDNm6DFQRja/vqZa4Ig564LUnW0n4qfXMAvVf2+SZNVZCdc6hlUKXGT7X+EzyrN7IIpbNPEO5GTqyGGuLqhvU+RqzXDGt9oEF59ezNtwcz9fmUTNpm1lD/aBknVvedfMBz0/v8+75PV5bHPGb7/4AujYoN2Nqraxwvd6g6gqPyJ6JlFdDLwH8Zoh0+lRYNzUQyaRYpUuQRLIItBPtDgmr2dkuStEyopNzA608VVrW0457AyHdt+IFADtFIeL5uXhc7Wq93vzwb4VLbbx6qhTpg2+i+9pf1XioVtEPwW1rconAZf+BxiTnmxUVyv6DfaDPLvIdIyhl72xHIH3bkaKxbY1aUaCODmluHLC+XqKcMPqqA8X5O2v2b5zxPTde56wuOSjWvHP6gI3L+Nsvfg/mU3s885tL8jceieHKMpnxLabU1xaYswq9XMPxKb6qUUcH2CsLXG4wpxtUVYvh8h5Vi6ZhfmaxhaLaV61agq6DEQmDckuBRgpOXda9AG7qWyX36gmPPRXGntkEI+eTmX7MewVygsq8eFHKCwGkcNhARGBRo41IPrWvklWoSuP3a0zhMJnFGCd5K5cUJ28M5sygDiqcU7h1hjnTqEahkBCm27OQBU9tZYT3YYMY7VLU7VfXdMsS9JqusFrLOld+Y9CVxhYeE5ZSKU9dUJyQfGNzvRAijO/uYcxzmY383UxkoDZOUTvQmRONyCwXxqYVCSZmoQZuIrcsLlFS70ltly2RQvOy0560sxCOnDgaGwgpdRBNNsGj2W/QhTA5vVXYcy01d6EoO196pg8d2WkttWA6DrSiD+lzR/76Q3xZ4PYmNAdT7CyjmRopMN8TWn9x0mDOG6DEPbUvGo33T5h89kWmH3gP1dUp9Z5hfsdTLzTrQ82j90nYWleK6tDhM4/WDq0cnzl9ihcWd/mhwy9Sf1jzj/R7cXnO5vCQg88ZzP1jvAu5oPUGt970aOdx3a22TmxQfBzHlG61dAu+6UKIkVmspWSit9xKMhakRb7eWvR0Knm1dM2/1LOCXjG0DD22HW9iG4G27el4tzWsDZd1Sq+NgcFLSpVS1rXKM+m+32D661Ibrz6bJWX07SBmeJk29hZqS6miSdFhT4wzVU1uH5rDVanh24GkVmNnYV4a3mxrJBLXeqvoma7NxqCyDH3tCvWTh63hWl01bI4Uy2cckytr9iYbzpuC03rC2uY82sz47c+9g8PPZFz77RXZS7fkuvMcZlOpwQHyW48hz1B1gwfsC89Q7xc0cyMz6icn4CE/bSjvLmU5e+/Jlg0TwFSGzYFujZVqaAkUJhSayqrGHj1VGBNCjQ3y4inAKuzMYWeg1xod6O/dTZH/XOnE4CmPKi06hLRsoIgToiI6MAKdVZhpg8u0rI+1NljfkR6EBANaefREpKAswElBdmIoT1TQZfRdzioc2yxl6ZO4Lli29C0rrjqUfVwGbuqEARdV588NupLr1o0og5SPhYHpChUW3dSh5qrzlCQE1+WconfjCt+Gbr1TKO2xe5bKm9Z7bdplSxTO+E7FX3UG0U5057WEZ+YLj96XHJxdZ1DLBEFVoirCRuONQ2WerGjwuhSljkrYluWJJz+RtcMAIQHNp7hpty6fWVeoqkYfO6p3XWV1LWNzoCQPFrz51ZWCYpmTnzkmd1fYaY6/eYiZTWC5ZnK8ZOIcVDXuxhWKJ2Z4kwuRxUB+qqkXmvp4n4+/8d1kS80nm+/CZ/C9P/hF/sRH/jlvfN8Bn/uN96CbPWbznOKl27KCtfctNT4aLH2w362jlqrHBwMh/SQq3+gehV2kn0p8VUnaIubNtELprFcPGmupYqgvemjdeGFDKU/ysrhAZR/qCYaxKY53vcl1ymQcRKm6yX//cGluKyV89PZ1Fl+9PaSNy228vEOCwp37mxqvtxKQ3D5cGue96Hy6fQhbdNAhvmYaaWD7DNtx4WHFyLqDOc0sw5aiTbe+qlhf96gnNkzLiixRl7+3XPD4ZMbB72YcvlhRvPZQPKrZFCLdvm5Q1uGX53CwJ8ZsUlAdlTQzyX2IKK7820xyzEbqd1CS5zGVE7X2QrVF0Sr0aa9kCQ2ziaEGWfrCZzK4uQIJ6YVQH5mwxLxX2FzCfb0IoSJxmBWmcGjtQHlsbhLvN50odF8PySDW6vadd2i0dijt8ZnDPM7IlqpTdtCKJq447IFaozeqDYXEZUFcLpR2O+nyQt6Ip4j2+I14AjqQPFRNUMWXhjQhDFzPu/ouF6sVwvFToeEochwnCz4QVsgczUKMlUwOpEbMrGk9JwgGrfFhOZlwrHi8NPVhxLj7XLxdr0OI1QjRxRjXT2u4yL70knvLw6BNLtqWeecxlLVFWVmfbHOYUS1EIstniMcbU84GnNGYqsSs5P1xZS7LvXgfyA8Wn4n3N3noqBa6nXTM7kikop4ZymOpu9scKF58cJ0nnjrju/bu8KkPPMv56ZRsVZA9cYQuC8kNn6/EqMSwXpqPTpVn0sm084Hg0Yfk0iCy/bYwTH+8WVok/p7uu8vFGYxbfT1U1Z+sD2SoLmQOXjD53rnNmPMKCF5V/zNdPDZhJfbUo3clHkORcvtdmE10hXfpeT0t6SKSPwIrsfXWep5gd7440/GYUN3e/kC7hk84VkuljfFyrSHPqK/OaBYGm8PmSHP+tCN78pznrj3ivJapt1YeoxwPH82Z/c6Um//wGHP7Ae7RY/T1a/jFFG8M+tEJVLW0abNBXT2kOZhSHYqoblx3qx0gDVQHGlMX5KeG/Kxp17kyG0f5GOo9Qz3rBpuoRZefORkYjcFsILpRtgSbhRc8c+hQQ2UrLfVYiCGLnhYKqEPiqNFtTkspjymtLLcS81uIx6y8kvqtWktRclLz5SrTe6d8DpEIUhxrGegbMC7UGGmEht1o1EaWY/EZYhjWYlDquRA07MS3JA8UqCywIysJi+o63jsJrRUnlnphqOeKek9WgY6akGYtxj5l+0Xdx6gH6fJwf6JIMKAWTStppbTHLnOUM2TnId9oJO+VrYVgoqyQLOogoqscqFrhKoMuLHnZkAe2pS9kdq+NYzapsF5xfl62HrLc0I5JKRObYJhDLZh448HjsB5bapY3tYgyG7lGFcOmgNdS81XPc679ToUOkyjyTNiLuUGfbVjdnLE50MzuSR+1hTTo6v/6VdAad/0QffsB6/c/Qz0vOf3iEb/lNN938zV+6V/7f/GXX/0/kJ8ZbLFP+XhG/nCNuXUft9m0g7Q9ORNvLM9oV2UmTqaTMJsfhPSsldxpmt5IF8Ak8WLCuNCqbQRSRnvsJP3QXwMs8XxIJvpJbVePkRj0ERVBE9YUfYZjK+AQ/hfGxR5LO9Fe7aU+IrP7bcC3hfHqr3+T3JxBTsnXibc0ZMmA/KYHtRc9Md7dfw9XDU1nKr0QQjMwpsFIpiKabQdP90/j2Fqhjw6xT12lmRnWB4b1NcXZOy3Tp854Yv+MeVZxXueUpuH9e7f4td/8Qxx8UXP1d9fo1+7imwa1mOMOFlIHVdWBwqtRB3s0T7+Daj8PWoDiZdlc8iNAy5LTtWd9qKnmmvzcMH9jg7IOVxgRe3UeZQ3VQnc1SEZCYbr2lCcW5Q31FJomqHN4jdUimRSXGCF3gfLuUbklK6WoxzZa5Jk8YOW++WDbi7Jm43I5RubQxuGdoqkMfpUJSWPaMF1ssFbjrKZutOSIVGjrcYFeK4pVx7ZDiyhsvfDYucxWzakhWwXvMXgY+dKzOexWDnZ5TPopzFLj6gJlFeUjcQVVI3mng69KIrs6kFBZtS8ely19GzqNIUHoDJWyimwp4VeLl4l5o/C5eEkql7yeswZ3bvChHdm5wqzkeUbDJ2E+h65cazRc4cnPdCtR5daGyimc1ZSTuu2zubGsq1yeTaNh5misFG3H/Fk9N63h7cgeuvUam1mBrn27knK7ZE7pgwfXeYwoMbAPPjCnPHbMbm3IN3Uo62iory+Y3lkxveVwk5zVCwWrG57qquP4O97F4hXPtd8+xdc1xf1zZnczmh87ZfXlff7J595P+aOW//0f/f/yP733fez9X+fUewb8BH2+h16v8Vkn6tsq1TvXiYHH9zj1xkDeY5N3or8JMSMVL1BZBrkJtHq6RR7jRDzCBVahTybM8ZgXkC96Qr2m2DYqqlPZ7xmulESSGMl+ferAW0sPOxI2CEZnkGBMZRl2FdXtQkJXTzUJv5Z1cNLtWpHNATOwV0yYhjSH7n80msMcV1IUqRdz/MGCzRVZT0SWxQAOavZna/YKUYU/W5c8Xk7526ffw8GLmoMv15QvPxTDNSllifmgBq6sg8VcFMHnJfVeTjPrtBC9pi0+jotBxlyIDMoSSqz3cszaoiuLchJ6UoF12F9dV+EQ42c2vl2/KVuJVVReRFqFgm2Jy5ao8J93OtRkheemfY/05ZwYMqWFsODDIOtB9g/ag8p4nIvsQo8Oi1DGHmS9eBqtzBO0JBFXeKktc1EVRP7NwkrCXgfDFUWAQyG2sNSkFkw3HdkhEjzykwZXaJqpoV6IUK2w5iKLkYH3Txe6RDxbeWYKvQFrhPpP5mmswtfiJZq1buu+4nG0A1VBfu4wqyRKEAyG5PmC1xsGY+cVLk4ygNoa6lpCiNp47KzB2gy3MkQFFl+G1zRhIKb9LN4/F1iOErr0NNMww7cebyQXaDbirdZzOaCpC4rXHopHNZvgShM0Fy0qN2SrSNqQCUe26d5xfbpidnvCvc8foIw8u7//6ffyb37Pp3n/9dv80x97L9f/uSPT0FxbkD08luV/vN/OcyXveo9xF99p5wNztsu374JvGjEQqfpGjPJA34ik9Pv47BL1nq4JqQe1nY9Pi5t70nlAjwS3S4kovc5d36X7f4O43MZriKjgvKMwmVhXNdge6M0S0o60a12s3eftZja71vFJZV92ie5uVbPHlV3jqYNmmnIOdbBPfTil2pcX0ZaKeuGZzjfsFxtmWcWj9YzleYl7WDJ9w/DkZ9eULz/EvvIa+vBA1N8XU8y9x3KCTPJn1bWZLGOSB8HWPMg8qa7guJ7T1S458KhWZmhzaChOYBJX+Y231wYDFgYpZ8Ks0soMP7Iq4kKSphJjUZcaihAKNL5l5tomkEGCN0bMIYG8HGEbbYLRcKrVKNTG43JHFNatayOMM+0xWRffVCqIhPtkgIfOW8glrOlWWScqbCE/76Su7MS3ivleewl9Ko/fBLZipJC7YCAqIb00ZHhlqGe0A7yu6JYKUe2ldv9qqZ3SjdDufQgPeiUSVz53qEa3CibZUry4eD3aymSkOPGiML9qaOZBx8+B3ijsVIrJhXPg2hCktRodwrV1bdowrcktWd6wsQq71P212UL+T4VQaSopFUOY0QtsQ6MzJ50O8FkWCCqK/MzTzBS1Upx7w96mgomEDUX1RWNqKfuYPHLkS0UWtByzc9dFXM5X5LcUT37iOm/8oMFdrTn6/xX8i2ee5gdvfJl/+3/3j/lfv/gD5Oea1X7G/utTqCshWAwdjaRoeCtH1CZW+2PK0IB1ufU+mzrZAbCth5aKCre5ttTj26pPTeqvhu30SRiy/d5vG7NUFHyYz0o/D0OIv+9zXqEgrlf0dkHBMvCWrmycafQM0C71DGArN9YeKPGiBtXqvRh1nkmoa3C+qI2my1Jmj+fnoEv5fO2I6qkDbGnIzx0PvzNn/YTHHtUczlfkxpIpxwcO3+Clf/4sV8IaXMWX7+A3G/TVK9h33EBXFr1cy4KR16/QHM6ojgrqsGBkzNW0K9gaybnYiQwwdiIzYLeUma9WClt4qoWmmShQU2ZffozJDXpmJNkeJoD1NKzSa4PeYCB6ZCuPMyILZZuwWOVEi2xRLkQMpbyQKhLZJnJZNFJpj13JMiw685jcYmuDtxrfBK+1sBRljdIOWxvsykhhsjc453GNppzWeA+bs5L8TLeLSKoY8szD9U+tiPc+LFqPSDcIKy6s+owCX3r8NBjgOPCuTUv/t6WnfKiYPPTsvVZjzsXwTx5rNse6zXW5IkROQ/g1X9KyGlsSBpKL0xXkVbLYZ61EhHcja4llK6j2EWV9rzAOzEoM1+L1imwpbEBXhEmCkkUh5QRKFuI04sEq7dmclujSYjLLdFKTzdc4p1ltJL6ZLyrsxHKWTSRMuaZV3gAxUi6+mr4zZHHtt2busQthlaow8XAKrM3aJXbyM9nXFbB6/9OUd5eY+8dki4JmntHMM4oHa/a++Bh1vsbduYeaz/E3rrJ6bo/p59eo/T38pGT+hQdcOXqC403B8UfWVL95k//njSf4H/7tX+Fz/8ebfPrFZzj4HcNm72n2XrvO5CsPcPceENfcoiigrsPERLd5MFfZflQlyVf18vGAynJZSNK7rmbLO1RWtqHG/mK2yRjUhvkknya/x9xUNyamwr49ZaK4ffshMTbDUqLhZL39PUmPpISRt4qCfR243MYrhg2Tqu4eUuOzi6QxFMBMj5sqX7SHS2n2iRc19Ly3ztM92NZlp4trt8cMBq/n9pclejZDLebY/SnVXk690FRzxeoJj31qw83rxxTGMssqtHJ84fQGey8rDl7aULwe6rjKEvbmqNqhNiLz5K8eYfcmuInBTnTrbcVCzvZ2aDoPoAkMtywMaOHlsGG27TKo9gzF0UzCOmuLvWpCPitck0fo39Mw43cSCipPLZXTuAxMLUQGn0m4zxkn8fc4YROnFZXLAIpCCB5xEG+C4QokCWUcSkHTmEh0bJmMOB+ep8daqfGiijGtcN2VGG9XIAOpV9TrrBXf9VoMhy3FuNmZxy4sqnRkhcXWGrcx0Mh1RZi1ojjxFKcOcy6rKSvvMWvH9J6TRTQnEm7Lz0R5HmCzr3Fll/+KoddIdY/szRiu1ZVqxY6bSSRmKPJTz/yOxWwcunayKObG4nMtxIqcth5NBbUM3yholAyMcuvxS0MDnBQT1MRKnlF78ra429NcqXEzgz7XFI9V++xTpRFZ9Vr6ly09zczLBKBwXZE5SMh34pN9FFrLRGv5pJR8lA6yRyuyoMmpapGdIhNCAt6hnOT21LNPCnV9vYEi5+ClFaaacP8FRz335CeaP/6//p/58Hd+maefecgbq+scfVqzvprjzTWm5yv8eh1WHPZtpMT7QEVXCj2d4BOSx7D2Kor5+qbuGYVYpyURms544IUY1ioGRVJE1FVMjq8MA4JG8Dhb1Y2EHzCMMnm3PVEfkuTS39LPCVmu/53j93fOa4jBzKJvGMJot3O/i2O3qfp7cuA3acMgObpr29RIBXps205nQWctfVYVBWo+w+/NsItCDNciMND2G64cnfHC4T3urxc4r3hczfj8Gzd4+uWG8pWH+IePpJjRaHxZoDc1aiOJ2ebKHDvNsBPdUrJtIdTuOEj61vXvZv3yPfgCXMjxqriIZCZrPVWHBWbtMLUQIGwYZM2GdnbtSgWVb8NhZuUwuUJbodDLKs+apgiLPsb5hKJLbQbDpbQXenYoMPZWCB+RGKBDyM42Bm0ST8ipjoCSOSE01EGfMH3krYHyUqPlwW+CtI8Bn0uOzE5EYNjuW7J5jTbBY6wMVBq9DscOqaPsHKl9CtR4Xxq8EqNfPlZkG40tRE1+8tBi1qJGYd89ocqlNitV14jHbScKYVKhq7BN2C4/g+LYM7tvmX/xoWycGVyRSd1eYAJGmnxUAlFBBqvN84VQcLaSz3bicaXGTTx23gTjJbngcm9DXWbYPKOpsyDATEfVD/3LlXKfbelxCwuZeNcmFILjlRR25w7nNK5S6Cx4pgY2hwpTSRlHfucE1dhwb/NQy1ig5zPJTdUN2crSHM3IHq9QJ0vcrCR//SH76z1uHc/Re57ikeLm38+4/cw+N+cnrN6Z0bx0jY0Dm2dMjvbhoRfGbjBWLawVEYCobdh6JwnzxlmprVRKVifwqZEKhiINBw6xY2X1FsFzu1BFKAogJMYn1VZMtRZ9zyHz6Qe+plBg67G99aZvhW8f45UkSfuLvMl3QhtOHvAu7yopLIawfarJlebDnO89vB4pIw0ttpV68sBkPS7TE88EkrxX0CNTOozoBnvziOqwpFkYVlc0uvFM7zqWT2uqRh7htckZn7rzNMuvHPCuv72heOUW/uQMXzfoG9dFjTwsKOmvH1Ffn1PPM5qZhPrWR2EGGGSMXK56K/nqRgbvZh7IEWGgVhYZTDJochBLAspmTB47ipOGbOWp9sWry8+dUNi1zLDNRrwuXXvsVNqQnUsxbxYII80V187MI3sQrfDBHVQqPl7dMg6VkRoqPKjSoY0Fr8SzwmAyy2RSs3wwC7VJFq2diPSuTcesc+IdVntQ73vqQyvHDkbBXqlxaxPCOpKD86UjX1Qs5mvWVc5mneMrTXYitHQ78cIuXCoOX7IUJw221Jw8PyVfOaZ3KvLbx9jJEcXtNeZ0A5sKPylBC7Hg0B61y5ScPa2FCarkfjYTcPvCTtRVeH4hTynq9qK47o3oJ9qjmUxStKKZGsr7K7HEyDNyRvQk49wvTix0rdr8p1mL0awXCk5Df5hqNs+K55nnlsxI/VdtHLWC5lwUVLKVanOD9QHYqcOXDj1t2tdPgiu+fb44hZ42+EJTZwavJRRr1rL95kBhywmzeSYrPVexDkyK5NSiJPvcK3DvAfnZOX4+FSPnPWrTgNaYB6e875eX/O5fuo69saJ+Y8b67z7Fyx+s+Zkf/Hv8yp0fZ/GFgskjx/EHr7L35RLzusYdn8jYE7VJvRfh3uWKyOATtYxEpUdLGYzHdypBrVGJ4YQhi9B3EZJBuY7KlYQP34yWno6VQXS8tyyKnFTGha1lpvp8gr7aRox2BDZ1kzgO3uO3EoS/N3z7GK/WKLm2Cn2oDt9tG8gbb1W4rNTW7MK37LR+vLf9O82FBUXmViB4QJ/thRMjPTZKQOUZqshRiwWbhahbNKWWxfimshTG/Dse8+4r97lSnPPVs6usP3fIE7/jKV59gD8+AUBfvyqrHgfFap64Qn0k4Uep4ZG8CohQrhTVemH+1bQLQLbqC00QxQ22tVWbMMHLCR6anUA9U+gm6agaqj21tU6Xy7ram8gyi8fTtZK1tHInRrOdb3ip0QrCuUp5IXKkj68IhbLa02ziAmPyjGxjsFa3LEbvFbY2sDHojeR6zEYGZ2egWfhWt09lDp3H91fBojOuSnu08Wjj2NQZ62UBJzlmrUU5/lBCUNO7MHnomNyvZO0q65ncQbweBxQ55ryhXuSsr8sDaiZxsc9DTC0Th3zpOHzJSc1UKLJtpqIvGUNy2oq6xfSBIzt3ZCtZYLI6zKgWmuUzU8qHDfnJhuI8yDblpq31ArkHGjFQKqxV1mopViK2q0NdmAsMyfxU4e6UVAuH3a+grKlrg3OaYn9DleU0paHZow1B4kFf3WCCx1pXmRBPnMJa8V5VE5ioue76XOh3Ub+w0YEZSwZPiLK+qcTDNZXDOOCJq7Iw5vm5KH7MprjDmegsRjHkTc3Vf5px8u6M8z96yvx/3GPxpZxffeLf4E9+36f4O9UfYP+rMhmrDkvK5gr+/sM2AuO9Fy8sFCd77yUPZujJy11YCBy8ptSYKB2KiHuCt6absCuPigYijoOpoPgA7dpjvYn0DtcoGlPoxqxoTC19zy8ld6Qq9DFU+fuesBGRFiO/WUJwqGzxVnmwC0J+Fxo938Wyu9hx2D4Kc6bHTjXItsKNCvICd7iHLTW2FHmget9TX2mYXl3x7OFjMu14Y3XASw+vsngZDl48w5+Kx6WmE9xiJkK6zkFmqI+m1Ht5WP5dkvquUB0ZoRTFc2eRgaSilVlqFWYUoiwek+tJWClCFqUkEDhow1hRpUMKln278nKkSEM4ZhumEoMZb4mP/3qC4QK8UO+FHi9sONcoyXMh3ppvxFCZYNCcVcL2Smj4PlDYo15fXK/KxTqjDNC+ZdZ5r7BOobOg7AEY48PxNU2d4c+zdvkQF64rOxdyRHHm2jXSlG1QpxvUphY1/70J3qhQ76UTKrksQFk+9kL7PvNM7m3kWWQalKzM7ArEwzXxXgsNPz+r0WcVPiiQ2DxOEpwsT2IDQcAoCftWRuY9mccj+b1WLDmEIaNMlak8hYF6L5y3gWwpfdqqnLVVosyhHWVZS31dXAA0KvV7KIoGrT1No3GVEQkqK2uqmbWWWreJx0WNT686eayY+9NgjbBj4/pywmrU5CtQjcftT9FaoWopzlfOtbJVbSdzjsOXNtjJhCv/+gkPZ/tkSzj7wgEf/K7X+F+efA9nTx2y/4qlWRhgSlnknQr90CjVTRfNGdqHARkCpSWMmChveGvZuShkuv8wHxUJH2+BNrKUbj9sUzpmpfmsNxl3e2HClMTx+zrnFYkau5iGu9h+cUbhEi9pGHzVpr9devwhpT6t7XAhNJkyiOL3EEgBg043rHdIPTvvUWXB2bv3UVa8mMff5eGJDe944hE/fONF/sXjZ/n0rafY3Jmx+LLh2qfP0a/elXDFbIaaT7GzHHO2kXxGWXD+1KQ1Ds1UtXp41X7y8ivxplQjL70t+s10mdQ5qUbJ4I9qQ1MxHIgX8kJjNSbktXztZRXhINSbO1nbSy4YzNq3s+dW2LcBvVa4PdAxN6g8CqkvEuc2FCfnjrxoMMZxfjKRPBdIITPy+3y+ZrmcSAFtrdBz2R7lqWuhkus6IThosFMx1GQePWtkDa+NrOEldWeqlZMCIYs0ZzlqrcnPNPmpKPybc1HK33/ZoRzUc835tZLyJCdbOfLTKfntY3yRY2cF50+WnD+hZZ0vLwxDgOpAZI3MRlEvFLPXrahLAJOpocgVttSsrnSkk2YCzcLIKsjnFfqVW+Rf3JB7j75xXSSPqgq1vyf7WEfxuKJ8nElNVchJtXqIwQvVjawAPTl2FI8bDl6sWD05ZXNgWF0TzzU/1eQnWgR2b1YcXTuVfmHkfmntqBvpNCrzNME7s2uDeZi3DMW2f2ZQ58m748DOnZBdbCfiDGGypOMkKyhynCuEPFlgCoOeFOjX7uLuPYDbFvWOZ7olgBrJHR9lV3n1f3ua+ntqJq/lPPWPLP/LD72XP/zsi3zpJ69jf+4ap++csbpimHz1CThdyjFAGMMhTCh57TBxjUXA3rXMv6h16H3QQTQmhA5DDnq9AWdlmFGKVj1j1+rxkWFoBxPyZJyUyFSytmAkMA0IZ+1YF727SA5pPTHVFVAjbWsJIwOhYBUjQd8g8fCSGy/dhQBTDGdPAN4K7XTncdqpvGx6gUJH/9Q7aKLh75Y5FBhBbfMCGaPdNMrAWGTNn0Bx1fNZW4wcdQurPYXbr3nPk/e4Ollye7PP9fKMz9x+B0/8E8X81obs/pmEKGdTmb1rjTnboFYb7NU9zp+ZBWJGYAwamcWL9yVirjGk5wz4ucdOZICKq+7WCx8o1vFeJ7c9zsR9mPk3Clt78qWXhHoWCnmX3faoaKQ8dqLaY0atvda7azQ2kjMQR9JvDCp34g0pj6s1jcpwzpJPGpqNhJx0bluvrG4MedGgtcMWmqJsaGojIcO1aQe9tiatkP+aazU6l3zX5jzHV6ZdwFIfVGSZpakz6lXwIKAlS3gNk3uK8thj1l5WAM5oc4fN3KCsRjcZsys5upKw7OmzoaygoV1SRTkoTlSrIu9yxfnTM3QtdV5nT5v2vtpJV6enGlhdMVKOsC7x73sH5qzCPD7DG4176irNXsnmKBd1i9qRn9QsXmswmyxMdCQv1RTyHIrHiuIYymOPMyIHBgVmE9RTrGZd61Y4WFmFneQ80AuyQqSlssyyOitRxuGVwjeKusmh0pilYXYrlGM0nnoukYKocUjmULnDlwpqHRY11bgy5ONqWi3KGCEQ1Q7F+TXD3IG2LghLO5nwGQ3LFeQZfm9GczQjv33M5KsPee5/PuKln1asbzacPmP49N95L2cv1Nx85iGb752H/C08+MhNrvz2Y/Sdh7jlOZ2SPEHeKQjq+iDxFIkYgwm317QLYfYIIBcQM3ppEqVRWRd6VHQeW0pO6z4Plogaeoxh/OsYiyFHnubUBqVILQuyScgn0F77N4rLbbxS9EKHqVFJyBMRF61Ds3XMhIW4RfXsb9fbZvj9YKbTemXey0zGxeXnOyPpFzOawym2gM2hZnNVqOB7xZpMW07rCffWC7IzTbG0lK8fozaVLJk+LWXmUzeo5Qo/n2InGc1Ed4Yr1HPFolAZDHzL3vM6sU8VKCMzbp8FhYo2Udz9G4t1vYvGkXaZdjkQ7WAMSW2PAhcURHoCKSFc53PfO4bcOxW0CSEqb1ArCafHMEsIK4pqhrA3myZZKVn74C2ZNmTViv9qsEGSyM4cZtIEoxlYjEBUk8crmsZgzzJUlKty4mVlZ4riVJh92kotWzMN9yR6uUGQWDdQ7el2Sfu+JxxulYX8vLt/3hC0AeVe1XPVPtP0HmtkklLPdFvTly8zikmGso7qqKTaN9Rzab9uNHaiMRsJb07vBsWPUjzRSNKQhSVl/S9bijq9jysDIL8rLxOmaETdxmBDeFdeG8kTeq+wK4PaBDr9iSJbdXm3rk94CVurpG+Fvuu0p1YmGGAVwrLhHtTIygXBexMl/VD8H4gVAL6uUUWONwZvND4zqKqmeP0x5v4N3MyxfAYOv+BpJjm3s0Pyd8D0jpQzVPuK9ZMLJtZLSLKq2jot71UXnTGGVj1nmM6AzkMLRA65V4nxSRUwEjWPLea068aW4W9vKUaebrP9Q38c3VXvCt02aZpmzHnRv2HeozIT6LRJ8tF5LvRR480c5rp2KnQM3O10u2TWcTFRRLX7qkEOLJ3B+KrCHc1Z3SipZ4rT5x32Ss1sWtE4w9rmrG3Ol758k+mZoplouHUX9hb42aRb/fjsHPvgEf77vpN6Pw8Fxt3L7DLaHEa7TEkhSgqEwcErSV63ixEi23njuwE/5hvisWpRPPBaZrmRjKE8rScAtDRvFwYTE5Yk8oEMEgdKX8oqxnLvlGxvJWTYGiHjsNFYKZF9Usajw5pN8u4obGMgPLq4nSe8S0rOSzAEzczjZg51UGGMwzamDUGqRPnDW4Vb5xT3hRgQKeX5KUweeGZ3Gyb31xJWuibMwGwl98tNZIyK+bUmeEu2FAX7ZhKo4zPfLi+Tn6tOrDbr8oqxzixOHMy6u9dC8w8sz0lGPZf8UXlo2rC0nYBXqp3cLLVm/2VHcWK59pmKk+cmbA4VdaMoToJhslIa4XIxFPH56lr0HaNKPYWsbi0zCMlBVpVBaU8xqyiLhsZqztdT9EpRnCjKR4kHnAsBw058oOOH/mmVkGzmNS0jdWKxjcY2itoqzEq0FfEqUPrluKIaE27QpEStN1K4b4wYYA3mrMLPSsgM6mTJlc/A4+/UZO89QX1uj8WrkJ2X2O8/YcUeoKj34Pj5jGZ2wP7pUo4byVohtKaMkWhLEh1qhRKiTqsJYwm21UpURdFJNzXd+CQs5vB65l3ob1vRIqHDDzRZdxLQgOHEf2dZkdL01DZ2RcPeRrIGfDsYr56npQY33W3dw26/ZLYw1ApLmTHpLolR6j34yKa5gDLa1TZ0seK2g/Qq6jXkOfrKIav9Also8qUnP9XYfc07rjwC4JWTI+7ePeCZ39AUJxup/dnfw+/NREn7+By12kBZoN7/HWHtKkUVlkePHpfZAHGpICf0Z1E1UGyuhPCgFs+nrcMxUjAKYM7keOnM2IUZbatIYWRZj3zle6GfWPRss649rXBvTsgJiddD5hG5GqnXcja4IyGc2NhwsDqEtrRqXTjvwHoTFIAs01nFetVP4mnlccZDpfGZF4+rcPipRZeipFE9CpTM3DE7XFFXmeRmTjP0uSELyvBxxV5lYe9Vy/ReTX7/nNWze1QL3SrDR4anTxaXtIiBaY17Hu6TFiKNK0UVf6U15f0YTosGS4yPtnKsbn2y8I/qJiibAyVFzLlifaXLewK93JY3sLqiUFYz/fIJB5WjOizYHMm6YDZXQXRY9YxmK+cU1wiDLgc1dxRHa+p1Jh6x8ZRFw3qTU28yqDTFY01+JjnQZpaEuYPihsuDN07wuheyvphvRE0FhayTViupqwslH6aiN4et5wrlMky1QNUz8run+OU5frlC37iGmxWYL7yKe/fT+LxE33vE9f/3lylP38lrN6bUH1DMX1MsXnecGUfzznNOFxOe+w3HnX895/ymwWxuMv8MssyQdW3+S14gI0oc1sliljFEGMcCaCn3PeX3qFeYTn7rqmM1114KopsGbHjBd6gB+abpfx8MTCRY9NbhugjD6FU60U+o+G36JSp5+N/vhA0fpslb373VfkmIEbYN1wWyUL0QYtAV23K3ZUo/+CqcSyWGcRhq9A7QqCyjefKIej+jnoqq+OaKJd/bUGhL5QzLTQEnGcVxQ/HgHH0qMXoVC5CtldBhkeMKgytFNmkY6jOV5Cq8VrIseyPGSFvwxzIY2inCCPPJvi4aQS+hxJjrcrT5llYzN5A42mLaAVwh5BBnZBD2GlF08EpU2wsJ//lGDuziwmDxWBvdhY8c7Ym7mqDQ1nCvnQs1X8hjyv7/7P1LrGxrdtcL/r7XfETEeuy193nnyeMnBl8bfAsXhagSYKAAqwAJENAERBsJYTogIUEDIdGhQYMWggIa0EOFaCCoC4KLb8F1IrhgjC/Gmc7Mk+e5916viJiP71GN8X3fnLH2Omk7MyndQ3lKW3utWBEzIubjG2P8x3/8/zZIJgvMXaiVVeqC9FOSktkvk8BGTA7cfjakg8Xspccl+n95lipIdt/ciWpF6h3ThchkRSsfMXap6veZ46lTdDnOPstxVffpzGSU8YTlPEa3QIXRrJKBepDBzNR+pJmW/db308vfVWaaqiD7nnaa8d1LVEy4g8fdzcwXjvHCZA3HJXAVkeECe9bPpWVOjrbMDWl0I5JSiayIkoe419da8SYTIlAWBi7iwKmcb5H2kusyXxsZui3nQnt1st9SzU0JzOywh4jZd5jdlhgC6jgKFWI9uGsN8eaW/oOB/stbwg/fMxx37D5I7L96jn42wvnMfNZgjzKYf/Pdjv7rO3RMQogZcyVVNq1frUTWbYWHSu0hSNDjQeWkWK1FQQJTZTJnROIB5Ci3RFn7lhbLw3Getdj4Z24Fvfoshnal7qtX//4tbp/z4FWu0m99q4Flhc8qk0/yQ9HJX4wmX4PDg+BXqfKPvHd5eRCvHtU27N/pmXaaeac4vJPo3t7z+vk9AIe54XhocbdaNAqv70VX7e03ZAjZe5RzpMudDGSCWKg3q5s3Q1t6AhqIpAqX6YQowk8Kv1WMZoEXAaJKohARy4KZFm29vKZU246yEGoqJb70xgpMFxqBgGQxzzsoga/3okw+ZbHXEozMEkzNUVeDRwCxUZEeWAymVjVkXy/vNU0TJAgkRWO9EFuMqDWEg0B/ustDraMRp+PLCeNk2Nb7HLjuDO5eVa8rd0+18jATuJsJtGJ60lYX5JjvuAKBpTaiJwPT4sBcFv7Q52OLJArVgZJVLzEhQg0FMjOlSknSDwzUirAEeDNIX6YEBRWXikbP+TVBgnEyMF0orruG/nm2HPnqp/A9rzGdmVrxFfHhpMAUokoJElbGL9TTEaMTMWiRl+oS1maVjKDAi/5iDS5mCX7F2FNmClPeeRYfnjWMqxIviatzCcS1Il4Hxdx7jEYBmh6w5w16OEMdj6T7A+o4kEo1o4A2O41/eM2z/9DyXf+Pr/A/f/xrUDHx5D9pXvyPjubJwN0XOtoXIpp9/25ierqhnTzqWubrlDHCOIqr1sZa31SpGrhOpKSK+7LKA87Zc+tkjQEUpjosP1hwFsp9zIjVKuDVrfT+Yipev6u//eLFwZoav3bc+E5vn+/gpQ15XJ28GlHw5LI99NkSqG7FBuRBpqHNq3bY675W/jk9hBvzkN+JZ5h8AKHBQn28GktCzY5UY9CvPSO8cYnvFOOluCJf/uBz3j1/yZPmyNaO/G+/8MP0/7nj9S9NNF/+WLD4d96ElzfQdai2ERUNLe+vDzPzdiPab7MEphK8zJQESgFQYOxSJaFTVRM/vJV7Ty5f+C7vYF6ch30v2a2eJdM1oUBHAs+4lKoV/HipamWgvfR0inhtWWGSF7pwLH2tra/5Q5xlRgkXCbuEPhrMQeOv5Lz52eBaL3JCJeBZqdj8ZNF6uSaGydHYQOc8zbnnTvf4WT5cPObb48zTbycaKwvHixcbCVx7UbDYfh2a+4QdAmaItM8H9H99H7Qifs87HL674/i6qn3BCrNqqUTM0coMks1jBvkcuDtVBWpTk1BtQJuEVwl7aOooQQ1iGeqbzyJxE+Uz3mWVjbz4pwbIrsSlRwnyWmVkGFtPkLI8VrFYmS4Uw5VhPOt5kp6ipojKKhx6LkWvIrkkNPacUIRNlGHyJmJtrrqiVEnhtuFoLbunB9p+ZoyqMkxKBW/GrHXoyKaZmuiFjAEmy4qpRQkm5FGCPJuogiRpZhLx4RIUyRWd30BsFe6gmM4cxB36Z38e8/QKnIPDkemqI7SazehRL66JH3zE7uU1/+q3/iAK+OTXGt79J3uS3nD33pa7X+V5+3/SNDczpIbn/0PL+dkTdv/sI9RmAzGQppm4P5ygPvXn2nYQpYw0jjKQrJLQzCEzFqdVJROq8PeJAW5pq8RAKsl4gQo/S0pv1Yd7KJ6wcOFWiXeBA+Wu4VWJfU4r2IcuGt/i9vkOXmvYcE2Lf+U5LNXQivJZs421bNQa9lv78pyU3Q+IGyfvk7OfVaYEq+BK9uwqnkiZTWSePSU8u2C66gTOa2UhOe8G7uaOmDS9mVHPG/qPE9379wIhNE4CWNsuEMPlGXqcSckSztta9ehQOQ61cpGZqrRAVknhpoRvlTC5Nbi9ZMPBqGztEWXBLNp0QS0qHLlAOOmDZb1EFRLdy4iZFPNGMTxV6FHJRZgs4UxgQm3jUl0l6XMVaC+hllNuE2mS3oaZIEya5BNJa/yqggNQZNkonU78p1JSHEdHjKoGNeskkM5FF9AmGuuZg5F+2ZytR8Y8LDzKe43nBnWmmc63uNe+D3sMjFeOabdSFVGZdLCNopEYFji3Bpny3JR7iF1CTQo21MFskeZSpdDIs3fgtxK4aGKmjcv5sUfqulLU5tHU6qtWNfkaUPn7pQxzKi8BZN4p9u90dM+9wJV6+azluoptIjVSVZqNjCUonfCTwWRjUBrpeSiT8D57gE16qZYydGmPqTod2KMkSEV9pZBclBf352Lx4ntVi9Q6+F6CWazFWb3+S4BWKaHngG4cjGMNIt1XXhK3HWHTYL/wJvp2T3x5zcXPKvZfgOkqogdP9yIxn2n2b3te/kDH9n3Ha//+wPu/ecPdO5bND7yH+drHGdI7RWZKRVRIFuu5qjKyA5zCiOvXr7QJ13DiQ3Pb8h7LmNF6Pfwm2y9Wca3V6h+TkvosEfRvY/ucB698t6wG4+A0izl5+jcTknyodbjOFB5Ci78YVb5UZVkv7uEAc3mOUvnwO0O6PMNftPiNBE/fQzzzbN3Ei+MGHzUbu6H7WLP9yKOfXy/fWSlwFsZJoIZNizpOYDV+504a8josN+7pd5DMucxdqbgcXjNI9hs6Van0hZmngiwkBa4q+zJ58SFJUItZxNftg1hzeMP4JEM7R1FPiG2GhBzyPhnaM1rmtOrZKjCljlXpXARjczJgpAeilOxH+l/5Mz/IS2JUIkHkNcqK27DJKhCpUXlYNGFN5Dg2+IMVQdrM0GzuZEe+lYHhouaAMjQ3NluoqNqiQedKswsiXzWaCtfpmTr7pVKuxDqZtVNZaDglBVkAF6jCyaHPCuyNBAZlI8llmxnD4gOW+2e136Vzz9FS4bisuIWewedApzIZNnQwXGncYWVWmq8H8vdbB65+M1ZW53x0JJOwJqBdSeFZHLHDqxemGUB3oLISfhUYNkuwTxrMMVWB3zJgrkIOvrmSrSowCSkOcnBTHiH5RFBjQHVtVYdXm570/oeYsx3+V78jAr4pwc0tlz8/M102TM9Ehb+5DzTXioNOHL84Q3S8/j+9IDYbxqdw+71bnnzo5D5N6XSIF8Mrw8FAIYctv74aZIryRZpXEOPq/9O++unrTpLvhwo/Jx8jvfL7yevL+6zp8az2uUaiHvue38L2+Q5eBTYsJetDfcOyPZzRKlVUmUBfa2893Oq+llK8wn4Fk16dtIr3lpmOXPpXHDtKxaWsJR4HdN+hn1xyfOdMxHMDvPx+zfT9R957/SWdmXl9c8fLccNPfe1dvvi/DLQ/9xHx5hZ1tkOFII7ISpG2PSiF8pG0afG7hvHSniwyUiWUizpDUtmC3feyGKrNg8PsQQeVIUcFxwwhuCTCIXkB8VuBduyBxWgww5LRiWzQ4TVbmYfdi8RwJYu9mUAPedDUJmw3E4MRtmC2lFcKbOul8IpIpq6E/DAbiG2uCHVCuyiCuUrhdpMw2TJbUinqjNeYPaeUjXT9VAt47438no/B7I3AiUGhgsrHQxa98TKTFows7irJYp9WCZQ9CAEjtAm/CxSoz2w80zNNuNc0N6pWxEnD8EYgtZltOWnUnYVJ0b/QjL/miG4841Emy5UVWG4+uuU26APmua6U+xLAtIfxSarVy3QV5GcvJpXRJmgVJptGAtVeRc6lYt7oaioZuvJ4Yr4IqD5I9aykYk1JMQaN7WaMkWQieo12Ypsi94mct2iyognC3mxvPdpr7CC6jbr0UsyCGqSsY1hg1PZlIlkhx/gyIB3z589BO7SZuKLku+lZ5vAAcA367Iy06xnfOqf9375CChHfGzaf7FH3R7CW7isvOX/yGtFarn9ghztE2tuEfr+DtweO78FH//d3JPnr4dNfqzj/2QtMjNKb7vusNBEFpZnE4kQ3elkr4ISVrNt21Q+jtj/SNK2gvXDKFFwn1zEsrMTHqq2TebGS4Z22Ql4RPs+vW7s2Lx6L8WSM6JvNk/1yt8938CrbN2OwrA7WoxnMihpayu/kF7mUso9XKrnV4N/CPnzwnuXvgcp2Wz6A0Fn1+Rnx6gy/0QwXUo0c3/Vcnh3ZuIlGB54PW7728RWbL/U0nzwH70W0t+9ysAqkmzvU+Y7UONRhwL95SdhYcTBOOass1VX5CjYHJEpmqjLrLC8mEXRITJ3M6CS7IlUAatL1eWaUasCDNMv9wrwrvZ5k4PCmlmzai7K6u8twVy9ZtkBdsQauus1iZ+9VJmEkJce1EDUUAjVqIOsUlgpRvL0KVJiYDouUiGkDbTfTOoG3RK9QE6PGmYDL82WfPD8T1+QpS0hl+/nhico6grmiMqnCmGtGn86wW2jy5/SKFAwhJHARf54InRYIq7D0zj362mHvhIAQsn+VipBuGsY2X89ei0qG1aiDzdVrpDsfGS8E93P3S3U8nWdzx7RUzjK4KxWYMvLz7JckJ7VL1VNsc/QM7k4GkyuBxEjiobWIH8eoibnvGLzBD5o0acydIfRRRhQA5cX404yqQnkmJznNXcSOCqIW1RAnkKaqVcNyfflCz8/V1nyeMMPiWi1D07L/0C5sxJKIpNbIrOjhgPKe9M45w498F9FpGeL+H57QvtjRfeUFvLxl99UdvtvwyW+IvPZvNBc/fwQ6PjYt7CK33w3v/r9HxieWT3/YML3W0+0HeHkt0k85kMQxDzlqRfUC00AskGIJCkvrQ7ll5OMhrf3RiqhAhCtB3fJ31TTwEJkq/38WizC/78P3XHzECnzzoKr7FdiQfGC/2d9P+x4ncOK3cABfef1n7OPheyzK0VRGEDGiLs5J5zvCWce80VWqCRtxNtCZmd7MvDz0pI9brn5mRt3uSSGium6h2ZYLulxERpMaXQ0gVShwUFqCl8rr94Og/FBoNwUlw7pNDlxZyJacLdesNkDSuVeXhOgh8zac0LYL9VlPMsOmvSjSS5WmCF4W6LiCkEq/i5SZZYoaQNFZe0AtgYusN1jf08uXTQlRqB9XSYwTqnzRJQSWoeXV+6dQqNjU6kiqBBZauEJ6fyyCw+WYlt5V7PM1G1b7yot+6oKwQvPvCtCDwt2rCpVVOvqk6oGtKutWiQ6kg5S1FlMb8RslvSItlV/YyOP1Ek0ZDs7HUeJ6rmZS+X5JzEEVUGb5QmYnlmNV4OT6LzGHTH7JbM80iHqGOShUMESbFp+wnGCVxMcOqUqKqZDkdwfKFMV8QRTKnJuMWVAp/4XtWIgpJWjV3lxmY5ppqbqSUtJHzlqPZggc3mrFmNOKTFtwjvbjFvX8Gvtiz+bjBn3l8ZsOYmL3C0euv2/L0Cb8NmGOnhZoXxrGC0NzsUE/76TSquvB6oKLcQlgtTn9CPRXNAMfG+9ZwYC1V39iCXXaFlFq1b+souIP0CYer9ZODS4fo8qfrsP1sW9z+5wHr1VJ/FD+6eR5S3+rQHnr15QG6drX5qTcLtPsANpKmb6y1S4sRmWMGM4VmurDvpl+wIR86xnzk47hyrF/S9O+SFz+XCCZhvvLls2Tmbe7a/7px7+Gy/+i6f/nnyaCGOmd70T4M3sQ8dbr8r5KMb1zSWiXysNMqQaaaJcGuAoFNsysvyg9kumMOmQcmsR8FaRaKFuhb9sk/SWlcp9B5KPmy4iaRMGh0K31LKw3t6cqtPt+ITKYQT6P2uaFet3/0Eh/KCgZPu3l+IppH1SWQ2ksBSW/l6psEg3ENGu4N4LY2QROgtLxruOoW2xTzpsiJsUwOeZcee0uDxwOLeG2IfrEdCEwaVnQVZLvMJ8n4nlkegbNp0aOS2bA+aces50J1001dKwyR7maTFtff9efNLh9tmVxQlYIOjFdRmIX0aOmeaFzYiGfww5SoYWQOLwQr7Jw4Tmeg+qCBPXRSHA0S/KnMxtTv8hLQj6uvs9/H6nVSzl32kugm7erCijIXJx2Ees802Tq8UxBo48adyfVdxrlO9ujQI+hBd8l+juRWXKHxPGpqYuqGXMlX+TFnLAFh9ejnM/8GYQaL6SaAmPbAfSUMLkvJOxbGWso1i9mDOjBi7dXiKRhoPm5DwjdFwitY3iqGZ4mVNKk1qEvzuAwsPnKNXzwlOFKcf2rNrz2Lz+ge74hNjKU/sFv2rL9MPLGv97z0W/YkvSWc/8W6ue+KgEMRI5qmkmzF9GaTuDB9fBxXkiWdaVAd7ltotpWEi3/GRXPGr7La6KyZT17NRn/puaV+rQ1Uweba0tlOl2TCw+geJV9B7bPd/D6LIZh2R76yJTtoSYXr5bZ1d24PL+QQUKgZiRrHLiU7Vl08sSnJ82kqNGNqfi26lrGpz1zmZVp4PiG4vCm4fDdM7/m6Quumj0/+en3cPafGp783IRqG8jGdupuD1rLxe899LmzbrTAH1oye3uImVGWyQRJ1UqhNvFTrhysKCXM51FUw01eXFfMv7rQgrAOoxApQp9qIAJITcI3+aYKqnpAlf6Iioo4lifLf+PTSDgLmC4Q7hf/raQTugvoJqF66hyX1qJAXthUxXCybLFMTwNaR4Ecy1CzJktgJVznRSB235IOuTfWRYINtYLYthMxao5BkcZW+n1KZaHXVBfPuMnfedLMF6LS4bZy/p2R/QWXSC6QSrU4l88pquolqMSNwQepoP0uCqHFRfTGg9dEIPSK+UmQyikq4lFLdddE+R7Z40z1JSjKwq6OlthH9G4mzpqYNCmqYhIgOomr/SqvUIXGrhPuToKq8dDcqYXtOGrUdqZpZ/p2Ypwd82zkc+RB4aQTOojMV7Qw76g9rO6ForlOmFl0HqczVUkXpGxemhZz0IIIKJ+Zq0dJkspWTDgLrDhvFliy+yRW6LG59ZijR4WAujuQZmkdpGHA7j3NncxK7t+LHF/T3H9xw9kcUJMnWc2Tn1b4rQTT+c0LtF9GHUAg+tRo7CAqM3fft+Pyw63oHs6ecHdHaU8oawWZybZIFeV5RDyh+HqtkZfS11/QIbOsY2uBBrWsZzWpfqTCWyfyD73BHq6bQpvP2UUJlnGp4JKfV5Ai39b2+Q5e8IsHsG/2us/CYR/CgSuZk8fYQJxUcwtxY/36+p5asg/VdYRO41stTLWLhN9F0iZwfrXnvBm4nnt+/hvPePNrgfYb9xKkSrPVi8I5KUKWkqFxxNZVnTmh/kYiAi9qqAPHZbBYZSQhuKUiElv7AhGyTAbkBfYVCEAJWULN62opsYj8qgzxiEmiBM5EzE7HZdfhTJr9qmA+he6uycEq1mCic/Aqw8YAxsQTWrCBKqSrTURbTcizaiVwKZMwJmKz+WHKIwzFoFIuLcUcZLxBm4RvI1ErlIHZ5lmmXEGpJiyswDbg+pndZuTmdoOfrFSEFaJD1NQnuyQGOi0tU52Evk6msWfVD2VSnulK+G0Uo04FpEyg6QK6CYSjFeahFo1HWcciaQPmE0fSmtjkgOSlWi3u2MmC3s1VciklqfAKaaNS2n2m7KsF7kuwQL0IOSaZQMjLjUrSPzODnGa/QYxPZ1God4esXp/n0aKjDiwXRut0kYTYoWTmywz533HRyKyMWL8wEUvgcseE2wfRXQTM0aMHLwrzBUYDkW6ag1RtU8Lea3RQDJeanTNVMX37sefmPTF4TUbT3EkyN13IfTZvFfu3WroXEd9p5q0mXV2gru9IYb+sGSUJXktBlQpnnRSXMZs8/8VK8PfhGvWZ69Zq/fslMbQf/v6guntljXysrVJEIP7/fs6rbA+Gguv2kA6/3rJ3DnBK0Cj6iGtdruyxg/ecOinnt8kaYafU19XHK5lPHhymbUXpvdX4TijW/q2BX/XuR/zo1Vd5f7hkjoafv3lG/9M95z/zAr78NcLhgHn9NVTudaV5RjkHbUMyBn/R47eW2GhpRnuxfJcVPpMzlF71qMCUHpMtxpTyu4qqXpt1Yc2Zew1McwnKCZqUV5j8pQvMmPs36CQDsjahG6mQ5mPOyG3E9AGX+06xSPw4ea7S1J5UigqTA1AIGmvz4w9Oc2ETpqQYB1e1DdNWvk8JctaF6itlXECd5cWsBLMcsA9Dm4mpEb2diaOQQNz5hFuZUaakCEETmki/GdEq4aMmvWxEZy+CfzpXWnhSCjXq6h2mtgXKloo1ulTvUmUlCIXRSBB0EbXxpL2VJMNGaCO2Fc+x42jodhPOecbR4SeDbYUMdP3RM+xR4Y0RqHIyQse/mogHecNNPzEcGtJsc1+NmvAUGbGigL/4ryl8lGMwzg7vRb2kcZF5LwQDmTtL9J9GzJTYv2kgChO2vZZAPJ3JvVFJL1aq+zknVvHMwyxyUnavaF9KxaV9wh6oppIFgShyW819yt5pQRRq8j9iRI0eNc2k3UbyszKPFVKt0HZfEXhzvMoJogYVEu3zkfQ9Dr8FPQe274/YwTE8tagE4xM4vKn47n9wx/DGhrsvWI7vntPPHu7uRXDXWrmvp+lkPTsJGLlvlbIbs7JW1pUQSNO0YvlR17gT25J1sp8Cp5qHpr7fmm24MKgTJGErVoWOstvHIMaHN+Uvdabsl7h9roOXMgalHlBCHx6wE7hwVTJTSmZeYerUp69mIB7itItTMjmTCFnMEoinors1EA4juu9QZ1sO3/2kDodOF/D9X/iYZ92eF/OWK7fn3738Au9/7Snf/y8P6MMAz65Quy8ILT5EodgejnB+Rnh2zvB6x3BpRGG8QCyT/O/uBaKKTlcdwlI9+Vay23lTRFYhZXiKKLNTyeYKqGpEITtxUaAgDdqFhWRR1NazWSRFSBfA5r7LCnpUTvQG50ODMhHtIiZ7ZBkTCUGj83DxPBpCEeJNECeDsvIakpKFPSia85Hgm0wnTrQ20LeBxgbujm0ugiMmBxcfNM4FYf8hwauxQZ6jEz5oxtkyz4a2n6Gfc6CSfylJIN20E8Ns2R8d+6+fZWp2ornRFY5TTe6/jZrmGw1mUPg+Mb8xixzWvcO+sLz+pSgWJueK+/ci8cYR2og9n/CjEQbmwUIfRG4pMw3n6Ji1Q+0NQ1LMrZVL34gcU2c9fPde/M5mjWmDfIeocU0QOacE4+jEqsRFOJgq7msPApHJILrCFqPIDC2n0eBdzI7IUoUW8eTUJuZdYt4pGX4nQ4G533r3rqnUfr/JfbBdHi9oYoVVNQj5YxTrmeZGkq5khSErQU/h9rFW/zGr3k87zXhhsIMkduKskDDHiN177N1IOtsKTP/V99H7ATO1jOcZarPCjv36j+14+jOes3/3IfZ2j/vBLeMTxd17G3ZfO9LceNy9zSoziel1z9d+1wWbDxO7DwJ371jc3Rnubk+63+e5UGEupxBqMiz2PjkpXveCYyIehwfrXWEAy/pTBHZPgtrpQkZhS5eg9Qo0WGJUXjsrW1GXMaV4mtS/Qg5ZwZlETmT3vo3tcx28Uswwj/wi/68zi1dsTlazBw9YMZ85rPfYcx57fC0VtTapTPG0Ius74qZj3hnmXjOfKcaryFkz0JsZqwK9mfnaJ0/ov+Jw738k+3SlkZ5V07VFPbkgXmyZzxqGJyL8GrIAr/Z5ZqZR6Ea+T4HsinXFYtKn8BvwW7GbWLySMoQW1PJYgRELmy8paRyvKV55oHY5QEtQQ6eqU1j2lbzGJydBKLPsUlLEoCvFWuD7vJ91kheFCJCqt5b8F4IWliFganWmmLxh086EDO3ZDBmGqDiOTYYZNTEIXV6CmMhCNbkHlhK1WvNzS1FHUCoxFrWImBl+WUjWb7Iyv00ScACVJGgVYgwKEZhVENuE7zXap+qgXARpw2SWys0KLJhMvg7rucnncRJrEBnMTQxe8zzfM8YJVV3rKAGrsFWTHOsUFbbx6AbCRoOXublkcv5SFFcyJFf+kffZ2iDnIWpJOBRyvypxgh7PNb5P+E7lCk4R28LMzP2jMyGn0Kx7MIoyonGikCHrKMEtuo0kvfiiWfBa1SSiug/kylFvNObM0CslUOFRoc7OIEbM0dPcJRmsj9DcSQDznSaeb9A3e/oXgdAaxktFc9ug50j3Qnpk5bo9vOsxg2XzcQmCBrvboG9ait6hcnZVAa1IX0o93iZa9aPk13RSUZ1YmLyiAv/YOhhO18Fv2lJZioFT1uGD9/kO0ePX2+c6eAHLQVkHrIdKGRUCfPC6h9qGa8+bBxRReXgZ1jtxUk5pmblIObMoJXtACBql37Xp8WctvlfMOxgvIb4+YXWk1Z7ezMzJEL++4epnA/HDj8WmXSmYZpQPQtRoHeFyy3zeMp8bxgtdm8OFjCFK3ArdycIhFhbZL6oBv8kLoJHA5beR1GRIsMQCk0TpG7IJZcEQkWw/ZTipBJayeCYWUkRC9mlSFtoVXrkykZSkkZ9GjXsy1gDoByuiqQrSpGHKX66XAHIiUZ8XW6WTKEtERZw1KWiUibV/NQep2t64uGMMhmFyWLPAlYehIQaTLVdEI9HYiOpl2LYEusPoMJlef0iqxtICUQYvLMhkxFZGdYGYZa9SUpiPWpmZaxLx0mcqPxL0vQEtsNj9Ow39p9IfSgZSK6zPdDD12KouDxhn5if7bKqoAJcEkvSFlQnJJg6TRjURYyNN66UqsxGZi1XS5woCD2udcG7Gm4jfb2SGqhXafMySYCqlmhCFNqFcxFoJ+sdJpLdC0HIeAFKugC6BTMnX40KVDxsZK/DbRHo61UHmdDRLkqRZZM5SZj9mrU6/oRpi+s2CNBQdRyD7jqXluGh5kooJ7Z0wIpXCXp6hQsTcjWw+aRmeOpSnBqXgFNOzLe3o6T8c0HPL8x90DE8NzZ1i84lnfNJIjzkotm/sGT89F+sbIHSGeN6jX/ak+322R2kEOqxLlQjkpnXllJNhldaahCUQBQmAIWSW9AqRehCsXqG5r0gdJxJ3a1RrFRgfeoI9RoY7KSi0Of0838b2+Q9esJTKZVsHrKJ2USrVlU7YiYvoOltYZxIPRXrLWzwY9CssmkWTLJBWlFZMvlgvd/itRc9wfF0xfdfAb/zeL6NVwurAGC3/r3/16/niP/Ns//37pK4lnm3BKPTtQajxjSY5w/HNDfNW4/uShVPhmzr3YvLPOfOcN7kJbmHepapAXp16fRZtLZUWSRh0UaF8nvzPgUMPugY77YQYUoaG1Zpa30IqcF47y+9JEbxGdR4xidTM163c5BHcnRa1+TYJPNnG+j4VLhxkoTfnnrPdkZDE0dh7XSFIFMyjeG8ZIyoazgR8Hp71OYjFpDjbjPgwC4zoDVpHumbm2ebA+zcXHA8N8WjZPj3k97KkCPPQQFSMNkof0CRMF6D3RK9FespEqRCjEmJKrmbdZhLLldGg77RAchsJaub/8pIXN71Uap2oVsTJ0LwwwmQE0tGgj4bYRczZTDBJ9CFdJB4sqRPLEXxe7RVyLp83BJvwXcTtJhnqnjTRLFJa2kVRgAfadmY695As9ijD1H4jCZA9CtOwXDdp0kzGcWdb5tkwj1ZU+M9mQhWFletUhHWpbMXYJKYnAfqA6zyu8XJOK6s0By4bSb1ibhLzFZj7PDxeh7yFMGGP60WU6u2losh2VUfoSYbmdYDDa4atB3sndO90txcn5W1Dcyv37uYTT/dC4bea+y803H/hNc6+OtJ+MuDuLfdf0Kio2XyYcPcCicbWcNi2pKeBT37E8ORnMzHlrKVBglMKoUKBpdeuipqP9ytCRDhVo09pWYO0qhqIa5p91UxcSTSdECeKFFUJcIW4Umnu6mTNQ7nV+z+s8B6Q4dY0/e/Q9vkOXtLQeJB1rP7G6kQ8Vsp+k/3Wk7hWXn5gXXACVZ68LycVWsWegdgLoUJ7YUu5zrO1E1fNnr1v+fn7p1z+J0330T1pmlFXT4i9RJZkDSpG4q5jfHPHdKazA670q4pcjymZuoJlODnTdXPVlVaLRVHOULOWKQBYBn9X7L1UqyikOtiGGuRCrowWmcnsseT1UskpmCa7jDVFRcoOt6UPllQS8dguCVyUHZvVvcxMifX8sujoAOOF5e5JS+xF2081ge5sJGR4MsbCFIwoYPQWn2+01nraTPabg2HbTiTgbmixOtI5j9GR1s0cfIe5MRyOO9JGjCqBZa4MfXI8tBMYNGmpjqKXwIyNtTKIwUhQSjLEGwsxIij2d3muIAeuMig9n8dqxkhUIoulk+gDughBEWe7JHSZ6l6NL6EaW6pJ4z/tlkt6hOZ8pGk80yTLg9YJoxKun5kjzNHCna7BRyoucZ5OG2E6KpWYJkvTeCGwgHy+JNdVUsJQjBbCJonZpoPUSL9TZz3E4dAs1xHUfmuaVktXRhlEWDhfR1mvUa5bKuwtlH+qdY+eRQbLTAp7SKijvMb3ivm8wbzM9+84Ye5H+hc9Zki0H+2Zr3rcwdOHJNqGn+whRtx+d+IY3txHVNDiTt01pC4yvRbY/vNQq0K126K9JzKI7YkxC/ErhJw0aqp6fB5QXluWrJUuahK9JkmUYLWGoMoaVXpZ6y0mGZJ+ROxBXprhysx6XNZGJZVfec9S/VUErPQL+La2z3fwKttn9LFgVRavn/4YLXRdMucsQRmBnl59v3gq6/+YfFSpwrSSi1FHME6MIRsxfwxdoneBmBRvuFv+7fGLfPnTp7zzsyPmxT1JK8LFlug0ykvwTY0j7FqGKyuBq1diWmhy9quoAq+K/HiiqhEUKnxo84xM8UcqUFyWkhJ6/KrHpKgzPyiEaJGDWQpaBl+zcSSFpee1zDBplWnziTBYlF56K4ymBjZWb5naVBmL5qBxNxq3h/ZFwh2FpWbGiBki46VluNIMV5r5XP65iyNKCUyoUhHnFeLA/dgsbEMdaY1U15/OG9pWfh6MxZlYIcXeeV5mWra71UyXirhTAtuVLVJdn5mkD6dswtgg3mIgyYSLsn4kWdB1E9AE4pzn4LIqRNy7XEXJWET0co7SLizwbGYdkiDNGt35KmOV2lgDq8oOw0mJXFhqA8mXoeFsPNoJAadpPOf9wC2dHD+ViElliFHhAaIT1YrsKuB7kZxym6kmMDEqnAlMJhJKrxNqbyxqiEaG2lMTwQq02veTVGyDhcFIwAm5v5bvM33UJ4PJRWG/XEJRIQP0LSIUXJwKZl090vAyqBydIo4yZK8nGRUIjcLvzMIQ9h51d6D9dCPDzNf36E2DvR2E7r7pUIcBrMEdIsHJDWgmYTeKTJtQ5Ie3pUpuno/4s5bQatKmg/0RNYykFFEmJ6xreC3DhMpogfO8l4NYl5yV6K3OS3uBFMvadjJZvECDgMjIrbc10zFXVg+D5SIFBay8xapiR6X5lzVm/eC3t32+g9d6fuoBXvtKP6tsNRNZQXzleZkNc5L1rPpcaZ4Wir3JUSGzbVArL531e+VMR9kW9cW3Ga4cvlNie3Ix01jP1/eXvNHe8q+/8l30P7XB/uSXSH2HujgndhZzmFGHEV5cM/zIdzFdWnyn8CuG4PhMFjDlRdDUjFDYVyFn+QVGFKXyXNmU+DQrUhmwPRoxeSzzXoFc0cRaRaWoBAr0qkJ9Kemqqyc27GJXkhSyb5MW7b0cKM2dyWoeYkiJl2xYBYW9N7h76D9JnH1twF0PqP1AvNhASOjDCEbTfCIzN7G1jFctx6eGF8OlODE76cGkwaBmRRg0h23AXE5cXex5vt9w0Q84E7i779kfW6yNXGyOKMBHzcuh56IdePuNa67Peg7f2JFaYUkmrzG7WSjxk5FjUqrIoIkpEb3CNiFLR7EkCfk4Ri96f2owEnBagczWQ9ZdN6P6iRA0x+sOs/GVNDIfXf1+ZidWK0knMXfc66rYr2aFIquaNDI4bg+5d2Wl4lVBcf98w7FveePpDcNsGSbH/X1Hv5noNyNsRg59h581adbMg0ZdTnS9aEQeBun/tq0nRGFxqssBpWCerJAaWl3p/WfP9syzQLt+NOxvO9Jo0HtDc6NldiuT6vxWruH2eabpa9EoFHFdsVDxnSK2KjshJGaTpE/XB4KmzrShExGN8lkwuZMgv/kkiopIp0l9g95tSfd7/Psf0BhNahvSpsN9dEPaH4iHI2rbi7OD1rj7yLTTmClx+e+fc/NDV/Lzz9wRzTmhM/jeM192TBeW0CjcfYf5OAv2GoNqGmEwHw7otpX1RmvSMBKnGdKYRXqXgHEyY7VGiFRpEL5KmkgxUQwtTyDJpsmBMdPpawBUC/TovQTJCkMuva6YlUNOqrx1K+U7sH2+g1eBDWsQK1Q4aqawPDetToJkAa8EtvLUECToaHUSCOUt8u8rYd8TYojVeW4sZyrOysW43eCfiCnkeKEZn0K7PfB0e+D7zz/hP96+jf75nmf/ccJcPZFhZGMwhyyzYg1cnjNdWMYzXe3XfS/zLzHDSEqEx3G3qhoVig6c3Oh+kyqkoaKqPSpReihU4LRIrUVkQS29kMEs5IzcQ5GAlRa9PkC1oertrau2yg5l2YUZwB407k4WH5HryeaOYxL68u1Q1fLHpx0qJBqrReFAa9DiLN3czJgp0twbfK9FNNbJsGhoZZECQ7COO9fROE9IIpJrbGSeLN4njI482RwxWiC9znhGY8V5+U2h/8WomA4N1gYhKLSeqTVonWgaz+HQVjh0zhWntlEunzzta13AT5kllmnwZfZsHBwqe2GFoGmcByPnItw7gk7oNshirIUA4mezVMdafMPkjSJ4SSb0pEh7oQyGZnUy8n70nSUeDR9xQb8ZsblXmJLAvt4bZMA7w0adx2SLk7CGmZPCmIAuXmwJmnYmNR7fGSG2QO0vSq/GkgYxF7X3GruHoo4hkDFVK7OsxyqK1xcINK5nKNqdfkcVmIizhmEh/hBkljF5jR6WHjFkpEJnLdAQIWQW4OxR40QaRlLjBLprG5Fqmz1Ygz16umuFGRLqMIj0mlWMr21QCXHfft4wXiVhRmoIncU6tyi+p3I/u3IwJSBV9rKrtPoSWCSoKNZjPA9Zfo9K35VEPq3mXVcuzutNkvzl8VOWtlr9rE/f+xX24beJGfJ5D17wCmT3sAH5mdtnyK0sk7lSnZ1AkY/2th5AhmvvrxQXlqFzhN4KNt/C8Gbgop150h54s73hX33ju+k/UnS/cA1dS7JGAlaShTxZTdztJKtscr/KCqU6dNLELoEkmISedXXDLcELnYV/dTrx+KpfLxsjCsSiFjiv6u/ljDWuvmvZ1tT5lcFibXDlwKaiIiEQivQcwO4V/ceJ7cceewjoIaBCRM1RLF8iqNmD0cTeifq6T4TWYIqpn0htoOeA8pHm+ZHkDNGKisT+bcd0pmQ04TIRvJBEdJMIUZNUwjlfiQGzNxxmhzNyQfmk0Zku39jAHDRzMHhvKrPOmojRFmsCvfPMsxXqfRIKvM4QIoDWClSi62YOqZXDZxO77SDU9aiZlMW6gLVBFvhClLGReBTaetT5mBc1kyJcXAbJ83kpLEzplSgUKZN40tIDyoPrKoDymnDrGLUE5dZ5Ji/fJ3qNdUGYhjriGmEsxij9Rb2ChZUSyNYkUes3JsgllYNzYSIWl2W8DB6bo2gSFhp8NZP0VKPTcg3rPGgvIyTrC7r0wfLnCZmdVwhGwQhUlnK1HzlBKCKiMl931zSyqM8z8XBAhzZXW0aEfFNCxYi9GYk2M053G7lWG4Xv5cOZUa75wzOFO0iyFlotgsCZnFHNKh8KZ5d+1jfRHfxMWO4zRoDyjk8Cyismu/UPDyq4B/2zdVD8b719roOXsg5lCrabMxXD6UDemnCxbhZCPcAPh/jW8xLrgb0Tm+0MJ55AiCmS5vSgWenlojeGeWdEJDeBfjLy+u6eZ+2ejZ64fv+cdz4I8OkLOD8TqafOEjYN7vme1Dhuvn8rlUSmJRfyRexz87Ncew7myyiLvleVNi9GiBleTKuqiwwbmlS1DFPIAdEmycjXm15eU8wg9ST6ewBqEAaEQj6TmcQjapHn0ZX11Vwrth9GLv/TLfrlnWD5NWjLDZW6RnqHzhC6bPPi1589oEIibBtSkcqKYD69w/pA6lvMuCW0htBqPvyNTqw7nLAOdRTa+Btn99w1M8fJsT+0fHKbiQw2Mj81NCbQmMBxdjIDphJvXN0Sk0IrITU0JjAFw/Whx9qAMxLsbkzP5e7Arpl4cejRChrruWgHXjQbJm+Yg+HZbs/oLfvJoU1k149cdAP3U5Pp/pqm8wyjqXqBhS5fGIM0Ed1E2m7meNfKMHNugpY5q9DncxUU+rCQbUKbiH2CmHDXBu875p1n8/otKQVSLgS6biZGsanROkkgSkLC6FuheU9+WV6MjvXyTJRcQ4g6BW2KUXpwdi++YvYg13gyQsmfzsQXzYxCzfdOLE3cfRK/siSD8WW4OWwSYRdqYgeIxFb2dFN7iz0qzEHR3C4fbu6z7UqA8arFfmzBaHSbje6sRW82pOMRpkngvBjFxFJp0k//HO5HfoDD2z0333vF9oMgQgFawZnOSIPi5Q8HXv/Xiu3Xjxzf6Ehdi2oawvU1uu/rupZIFUpkGGXdipoUppPqaE2gqEPOcPKcNeFs8TR86H+oTrkCa3k8Vsli+b+Q0wo9fyVaLuuF+W8SzD7XwSuFQIr+ZKivbg/hPvMqcWO9n0dfs74IVGb4ZC2xFBecWFWh3jwNX/pneb6rSLjoOXH3ruXwVuLNq1u+uHtJSIr/z/V389q/Mey+cicXqzUkm7O0+wl/0RNbQ3cdZBg597pEeFdciWOTFopwG4VZBqRGREvryqHkX7VaKNWQXhE3ygBxsdTNVZLKihui2i00ZBlqptqcFNSovCzZxLwRx2MRilX4bUR5hbvL+LhVzJcdLiXUMKNmT2qdQDYpCRxjDISEGTy+N/U9YudQRiBDFVNmZSnph2mxhiEm9GGWhEJZLv9L5HZ2HLUw67RK1bfLaFHWYDNyzIy3lGCYLT7oPOuVIbKouB/a+rpdK/N6h8lx3DfS53LixHx1tq/kj8t+YMgLe4iaxgg7z+jEYXYohCASo6azHqcDJp8LqyO98xzaiTkYxtESvECVuvNMzztKL224bxdCTFFDUQiUmJMS5RVhF/MMnwSzlBXmkwFz1MTg+CRc0F8OVVfy/qan206cbwYJvMbAitxktMzGFaan0QmlsiN2UrhmxntDioYwG4ZghGnZRtibjCLI9WmGrAFtJHDpAMGwWJtYob0L6SRD407ISEW7SpmEbYX5mLwm5MBl7xTtDegp29jo5bIHhEyh5TpMIQp1PROn8L72llKIAik6i+pa1Mt72o3l7h2LCgl3N2PuR2J7jpk0ZlQcvjegokXfT6hnHalz6E0P19dL5bXqYaVpQjduUYAvVdZDJYy6rj1Y6Er/q/x9xUpM4YFU1EqcvPS4Tvel6j4rWzG7aZxAkw8rNfiOQIbwOQ9eckAj38wY8lEfGqVPiBiPZQUnAphle1hKr0ghyvDKewOCSzdOFmOTbRhm6Q283V3zfNrx/v0F2w89+vYoAdIakhNYSN/uif0ZKiWa6xnfaXyb0Fsx3dOJWv2U+a3Qlu+ZThaBCuGVr5QDFyA3uuIEzxa/i0zI8FlFfJIgVNQM8m4kaEVZqBeufX6vJgqEmV2IkxN6fhgNfgPjpcKMDduQ5IIMQebZHmwqJfRxRl1IoyZZVSsw6VGoU2hXKYEaW0fYNYRe+mB2SLh7GO8M6Wz5qABGiU290ZGQlSFSElbionWYv3eGwsoxKP2eIuBrs7xUGZCOSTFm1uHkTX2/8rrSXyvw4OQNc9TM0RCSwumI0RGtElol5qhprOf+0Amd3USZ5Z6EAFIhtNxri2VYGWrgUhHpmeXznzKZZG1SqbxUKVPvsM5jbWQMWiC/qDE6ibRWhucKVAhihaJBiCt5tg7A5c8bjKZ6rSnEpibPKxbHYxXzgHFCmIFOglS5rkNXqi2B0MNmISLVa1DLqISfjZBjjkaqrhER7k25cmOB2lUAM4jyvBi1qoyySA+sBpg1dB2TGMXeH7AvW5q7TsgjncXsJ8wxZthT6P+hUYSzVr6zM+CsVFiF5ZhRnZRRCPVY6+KbbY+pDZ28/pH5q89YEx/b1qS32nf7ZvurivK/0vOS7QEVtDY9Q6CwACu9/YG8P0qLbuFJb2uV0ZimlsInqhqFZgoknxZx3kzQAOpFrdqWuGmZt5rdNwJJGV58/5YvftdzbnzPxy/O+d5Pj6jjSNKG1DpiK9Cj/vQl6skWFRP241t6/QSVGpIV0kZxjU2jykxCCDtVA9dJ30onGeytx03+lnSSIeAI67kuNSlhHWqqjbo5qkyxB29zhqtBZ2gxIe+tikSRXilplH1nZXSv5LNOF5rpQqN9Qw+4yaNe3kLbLDCi0RAjaj+h5w2h1cxbS/vpIL2xlAhtFqgNidQ3qDkQG8v4xobjM4NvZeHrrhP2mGhfasI7EkDKJu7JMr5QAlNjPU5HGV6OGh/EqsTnqkICnGaYLY0NdM7jLu9rAJyD5ua+r72gabQSbGzAB+llFQ1Fp6NUVLPlkGFLgP3YcN6NtHqpEFvr6Tcz78MSGEzCXlvcXjFdRMJ5QHUBYyPJRRIaNWnMva7n3t3KAG3oRGFFD0LsUJFKBLJHxXzn4Dyx7UcOtiV4w35o2PWjWMYkxTDLiEFMqs7ShaQIuT8ot06idWBtqcRYZLm09DLVLH2o4XWBubUXKLH0b4tBatHxlFk35BrvgrAvJy0wYZYd0zrJUPfe4O4VzU1mLFpFJKuEFDJIkCqv++QIIa8pSsk1OXuB78r8FdQeVEoJ7Rzh+Uv0MHCxa7n+VRumrSbpDXbvYVAob7HXlnmnuH+vl+/QGHTboM/PSYeD7LZtRXDXe9IUSGUEp/TG8nq1XpteIWWs18kHgekx0d9HVTM+Y1MmCxesyW9KQ8pswwpBrgoKm4ebw8y3s/13EbwWbLaU98uBrIrKDx4XZeREZdgoXpl5SIE8o7UEqjq8nOe3KNPjUYKbynIqZRaDlIjPLhje3JK0iILOO0Xbzvybu+/mX371e+l/aoN5/+flg12e4S9a1BTRk4fXroiNIWws49PXGC9EILW5S0IfVvlm3qpccYlKOTbVmZ789SsLrUBE+YvK/5NelOCDwl4bmePJszmxlUFSv4u114VK6EktygZ5GDRaldngAi/6djE4THnWJs0ZonKR0EaOl/Dx1tJ/2LN7v2H7jS32k7s6O1NgVBUi9n7CDFJFzOeNCA4bhRkCfmfwrUaHFncnfYbhypCUwg4JfQ/Xv0ozPonE8xkbdK2CgGpZLz/nQ+MtWF8DEYDWkUZHJm/pGrnGxtlxGNqqzLEfm6ztJ+e7KM4DuMbjbKgwpcCBM197fknbeK62B4EvQQLZvkMhgaA1gf3UEHLV3DczMes2urOROSiS09LXUmTtyHwNaJl5Ctt8HZgEyUpiMmhiSJhBVaNSu9cCz7rcA5taXoyGy6t9/fwF+gxJcX27wZkgMGE+no319M5znK1UoFECfZsD/ThbjkfRlSRBuppkAH806MspE+0U/mipdjJBQe5fAdL/C2phvGoRFDZ9IHpFmDRjdKjBYAYZEYCMKgbpbwWLJIJKgpqZ842j9ariygFi0xPv7paAkantCqBtxFwyROyn9/hfuyGeaaJtuPpP9/l9FbuvSgNx3ijOvzKJePB5j5k9ab+XoFU0UTPdXTduWduMgZj9A/0iUfcYi3pJ1IufFo9DgYVyv/p7lZ96ZEuhPCfV/5UujG61fJ41GeSx9/4Wtv8ugtcr26PCvK+ydh49gOsmpVkFxnWms95WuokpCttI9iv0bUIgbBpCJ3Mfd+8a9l8M/N/eeJ+9bzk+7/nClwNpGEXFWktF0czS9PbPdozPGuZeLCL8VmC7SvwIBeKQMqrqGkYJxjWAreHCshXli/L3fOPrUctTHwQ6FaUaK3ATSsz/lJebPbTymEqLukHpo9TjXpQhVDZwrL018LvI8XVNaA3zpme7s7QvRvFYihEVEsoLE7FsfmtIWXrL3ecbyMDc6npcis17NDK7M7wRSL1k5CazB11Wm2+dryrypRrSeUi3QF7jvCwgwBLsosKYWNmC47goVFSrlCBMPWdD7Z1ZHWXBVxHvDUrBcXb0bmaOGhAqeYET55zFGi2U/snbetn23Uw8MwRtl8o7+3FVJZDIcj0oSShUlPNo4nKtFOhMJQSuStI/TUHlYyOq/AEJqnMwKJ3wwRBjypCinKuQVD1uxeurHOPW5cRgNiLGnIlDKQ+9K5QEo7aQLZIMYhsxJSUhTTEDxTInGhmKFmEKeV5KqvqRRQt0wmbUk8SlAgwkC3i5dvRdHjCzBjx5HUmrauyRhX2cKiNQjRPuAHMWZo45CUtaRIhT7rG5l4MwG1NarV86CyXE+h4nQ8sPe/hZdWOB7xbiGasg+FC44RWFDHnRyd+rJcorYuerwejSRnn4udZQoVILSvZtbp/v4PVYBnGiKq9PDurJ8155TWbcqGVqXFkrTsVlYvzkteYBI6dkGYXiml+jMiTTauwhsv9C5PXve84fee3f8P/88P+Ke2E5+99fiBBnI6SQeWdoroEIxzc6js9EvzC0AgtK8BJNuTSlKjhalOLll3yTZUkgVeY/EqeBbBXYVBBChhnydy2QZH6u9krgnJLdJmF/qZUte5KWiZgalvcqh1pT1SBQCH3ba/msAZKLzM8i81OYzy3zrmHziWXz0Yi9GWEU11nlI2hNtJp5I5WBmRJ6DOhZCAq+z1DTEZrbgPaJ6cIyXSi6N/cyo3V01cbE6cjzl7usHC8QYWckYJReFEigGgdXD6FrPHNeJGJUbLvCtBMigtiQCFHAz1J1bLdDfh9ZUK2ONFqqrxQV82y4O7a8tiJ5NK1Q8UFkrFRmNm7dxDduzwEJghe9LLZH4/CTJR3NSdBSue9YzkeVJ0pU1mhoE1GLzFg5h8X/Ta51KvEi5f7bMFtiHkiOWckkZGYkSPU4DA7nQq1U52AgGC42RzbtxGwMx9ERgxabHJ2YBluTA5UZogBx5SKQohIpLiVBqpiShqDwo61/83MmgmiBHfWsxMc13x8g3zMahUGSHl7ewm4jyasPy30+z6i+F9LGPC9BJUbi/rAgL+NEexNQUUR8Y2tQQVQ9pvN8OIPCXN8TL7byQCU+aHAO/HGpbIp0FCytjOKttQ4aRQwcpD9XTt2afLEiW0iQDMt6+UDsQZ5/GrhOrFNSOiXFrQkdxuTWjHo82H+L2+c7eKUI2lFU3JfHFmPIFDj5+ZWo/+CArjXB4ig3WfKZAr8SuazUfL06SQVabHL5nhL68oLQakID09YQtoHOeq7Dln/71Xc5/yrw4SfCjHvtivHtHe2LGffBNaTE8defV4uH0OW5FQPz2dLEVglUVPhusUUvM1lqUvV5wkdWdc4raQkYp9R3CE1aiBkRdM5KVZLFDeQm7z+WABVaGK5k/gwksCYjUGNV8cg9t6KNqEzENtLkj3NmqrUB7WQod7IJv7Ec31AcXuvZftTQPZ9pvh5Rw0zsHcc3O9wh4u4D9m6SDPbWk5Ti/gtWWGpDyizPhsNbiv13eX7N0xe8OG54nu1LCiwIyECu9SIjdWwxJrLrRm4PHdYGWlvYZZmMYDTj0QgZIldeXTOz68ZMCVe1L+aaReS5+FsJ3NfT2MB5N/Dmsxuu9z3HfctznXi22/P65o64veXluOE4O8bZ1oom0Qj05otKvrAhd5uIPTtyc9+L8O/eLhUXLKbYQaHHXDk24Nt4UoHYQ05GNolw4VEuYmzKNjICo/pgaJ2nsTMbNXEYGzyaGOE4NsI2NJGuE0WZxob8WpHvujn07DoZhi4VqkqJlLI2pIheok3AGPF1K70uFGgrPUOthQJ/vGsFBo8K1QfiZOSrBwWXM37WmFuTR0jky9pDyvChJIPdC0/zckRZI9JNKcHdXnK+dYVSBHML61BlObK2FXTBe7pPJ5Ju8VcKPed1Johp5ryTe3l654ko2h+9BEZrSdNEvL8/XV/KWA4IyxoW9nMVSnAQAnH9vBBIU1ERknVLZfX6ddCqa+XDvtjDoPMIvf6V2bDMQair7Vos/Tuwfb6DF+SDnhfU1YFZ+9KkmCnsjwWusg/ZwWmlVt9jhdfW7GYxi5OXxqU0L87LriE+OReVCUTss7068ub2lm/MlzQ/s+H8K7MI8DYuD4gmUbNWitQ1Us0YVmrx5BmvFSvLIIyoIj4aBAI6IV/kCihlgkWFhbLiQJ0Fyz8XzboKHRX4yIuagRkSzT5xfKqZz8RSpWTpSSH0axurc3Lx4iozNoWPbJw4JQeVMI1o/sVZIK7UJOYz+b6+NwwXmrPmiu6jA2oOtC9ngXZmgRKT0aiYMFPEHsSZV8/yfe/eUwxverqnR6yOnLUj85lmf2wZvSFEhXVBfL1ml3szCq1zgJks4+DYI6oYorathL0WlvLUe8Okk1wGKtWi86wfpRqLuvaylEqi/edthRBjUrTOo3bSy0pJcTd1OBMqgcSasGi2lsd0RDnxHVufd+fk2M9TZhoGhRozJR1JekIvDFjlV1W3kkRpPsv6l1tPu50o/mp3h46uETkooEKIhcRidaTpPD6YhXia4UKBYKkBeBotdznR1zpVmxYAbX0efpYZsjJErmys+0sRfLArpquqcLQMI6s6rF0NUrPfmplE1UXPYGa5Xtprj72b0Ptxue+1Rm86mGYhZ+XqiDwKs2YnKyu2NCpFUBb7Yk/TGoYnDYc3W5objxkCdr+wKc0YiE6DkdfHfAB031cKel2nCjwYk1RMmtVnWK9LOSit3TNg0Vz9DBWN9XOXA/CwP/Yq/HiKZul8Lh4JeL9ClT/d1hXQYyybRzHbR7YTA7gazNTDJ+UfcpWm1aJJWZ5rDKptmJ/0NbvzO3h6vudZs+fT+YyLn4tsvnpLihHlHEnnxXc/kawhbnIFV9bGsi6VmSwy7dzlbLlAQlEWosLFKIFPJZmVKYoDusxs5c8u0klUIVQ9S3Wnp9wbmEWNob1J2CGKasBGrFVCJzBMfb+tr4uLcYHgBc5bL0wiHxQFAlLCugtR9PLI0lVpE4k7iK3BbzQohxk77P2Ee3mEkMAoktUyoJwSeoq4vQiiKp8InWF427N5bc9ZP+KjxqjIeTdyGFq8N0QtkJePmjmItUoZpA0xK77nwWD91KOyw7Mf3RIsFMQgdipjHloufaptMwENkxf2YkwKoxK9m0/YjgCt8/TNLMzDqBl8R+/mPAQsKh8p9+BC1DkQJKwRBfyUDCHJHFox0gxeRKbTpGGE4rOWEtAmUtJCUhhk5i9aoIW485g+0G9GOucZZsvRG8Z9k1mDHpfh1QSV0GKNEFAGnwhZeaNsixHoErCnUYayrQ3YzFYMQeNylVZGFmI+F9ouxywGRZp1DbqFsCH0+AAYWb9VgbvVkqCV6zskcVOeEnY/o0cvB8daockbRWob1DhByEIFWZZMlgq/3PfGCIxYAtr1HW7XoeeG4YnGTAZ3O+EOiflcZiPV5MFm6CL3ykGCEjEu7YiyZdsTqeyVEDtKsh5A2QdVTp3bSos6x4Me/ivi4mVbV1IPe16PqXmsUKhXJPq+g5v+xZ9yuv2Lf/Ev+L2/9/fy9ttvo5TiH/yDf3Dy9z/2x/6YDOau/v3G3/gbT54zjiN/8k/+SZ49e8Z2u+X3/b7fx9e//vVv64s8mkU8bH7arDNYGIX55xP7gNWs2GKLok/poyUrWcm0yCCyWgQpM8Pm+HpTg8f993iMSryYNtz5jv65Rx0G1E6w7uQMoTWS3fUNsXNsPo7oQD1TzY2iudY015r2U4291eijBAY16QoBnc5yUT0kRZmbqlxeAqLfJMlEMxOraA5uv5G4+tmZpz898uzfH3jjn33ExX++wd0Frr/PMJ1LBagS+CuPf30ivjZJteU13Dv8RxvinSMFzdOzPX07Y+1yMxoTadtZFtgoquuqC5izGXs243YT4YlneMtz8/3wyY903H7fjmQ1applbOCsRYWIngLmMIvf0icjZozcfI+le3qkdZ5PX57x1ZdP+NrLSz68Pj+5nzatVBbzbJhGSwyGabLc3m3Y7Eba81E8qbwWjb9ZyBXKivK7Lvp+QSq1/bFh8kYMLGdHKAO7KtFmSj5Ab2faHNBaE+Rvuc92P7Rc3/e8//wCrRJPuiNtVvoQpp/i/tBxnJwMW2uBDZVKDJNj1068eX7H5eUe282oNogiS7lGTJKK3EgC4nuptvxFJF3OPHvzlndff8Gb53eS7EfBj83HDcdPN7y43RCi5vbY8eJuy/7Y5qHkHHhnK+MAeU6uJDQqD4Zv2omLs4P4rGVNxwRVNmqcLN4LY7N4i6Hk9cYGjA1SCbu4wNKlyldZtUPH6gNXTFFjmyrsGFpFtOJC7nvNzfduuP2BC+5/4AnTe8/yHJaMaiQv7L7itVUeq27qKgsblN7YMJCGEX1zYPuRrA2hUcTe4vYR5QU5mZ5t5HsNnvjipaxnIRKPA3GaSX6Wx2YvlVgIVa4qjuPCqi79qoeSdXVNjPX1D6uruobW0aMH62ElqCSIYXlPgJRE8ahpKpz5ynqszfLvl2pP9U22X3bltd/v+XW/7tfxx//4H+cP/sE/+Ohzfvfv/t38zb/5N+vvTdOc/P1P/ak/xT/8h/+Qv/f3/h5Pnz7lJ37iJ/g9v+f38KUvfQnz2JDbL3X7DOrnq0+ToFaU5E8yjlJtlQxqRS2t5XimplbGkXOkLNtSjeCyo7PvFKERCw1zNkr/AsX/+tEXefbRnnR/QDWO+PQcv3OSxF/fyaDjHNj9/D2+OxNIxxUKOlCZhVI5zVpX6C92QmiQQeLTi0TPaoEHQ876lGTcOtPX9SzN+uYm0d4EGayMMgeDUsxXPYc3HH6Xag8ltgk1aRg0KiiitmLfUK5fr0iD4ePrnaiMK4G0yhCv9wbX+lP5yFz5+NmgnSile504YPG9xrfnXP1HhMByyNlyEIp297HMzUyXlv0XEo2O7I8t8brhcN1I5Woj3cWYWYBwoMF7qZziJBIO2kZstknROZOPUYsSfFBoG2u2H2dDnKn9PJDF8zg5wNG6mS4LAYPAikZFBu8qm3HrhPARUVwfewlILjDPpqpyxKQIuXJ7sjkK+y6/z2x0XatSUlwfBXLcNjPHsSHFSNSz9OgmmflSQTzBUh9IV1GU8VWi204cRsdxciiVhM4+a9JkMArUqJlvWu6N9LSsDRJwZscwIWMCudfX2MAUhH1Y2Jwzp+sqyGtK1UtShKRrPytlWDECYdaEWdyZbZPn2IySKmwwdRwjAmEwqFFjRyXjA0mud7ViXcp818plvIdkDLdf3LD5ONLcBDqtMTGR9gfSXe5FRYHl6oKdkpA4UkL1HfrinPTyRp7qFO1NxIyJaDVmTuL+kK8fv3MkrWjOdsS7ewmUISyCu94jZVUmaVToUi+BZjmQpwFVA3FhUC+U9tw7fUyN48F6+goZ4+GWYi7+HvS+1n//Dm6/7OD14z/+4/z4j//4N31O27a8+eabj/7t5uaGv/E3/gZ/5+/8HX7H7/gdAPzdv/t3effdd/mn//Sf8rt+1+/6pX+YlEuHbxLFT2yuMa9mA8sTl93GnCF+VhxVur5nSgld3EZhmQcpShlGrEvmHbTdxNv9Dddzz/NPz3ht/wJmYRn6805YTlMkDYMUTlqhh0mYdLN4gNWB4SB4eTKKZBRzyheoTjLj5Us3ewkwsLxWPvzyuBlVrdJAYEIzIl5EQcwTY2OI247x0jFeqmwBn2FNnTAHjfYq29arpTenyXCmYr5pCVtfBWflGMqxbBp/wub3ZSGLClXEVHXCpwwTas3Z1zvpT4wedZxy40TBrJmvWo5PNeHNkRg182gxe3ErjiaJt9qZzBGlqPEqEbyRxn4EkGOrs6q7zCGVf6eXTbkUCYqEJkYJdDKjpAle47IobUgqiz4IfDbnAWOzqkwKFGkz9b5sYQUXmsw2HL3lOFu8t4yzo7E+yzGlLA6suewHqWqcWLPMSkR28QghwohCfdN5Bq8FelaJcWjyuijQHF6CHVqIDelgGHtH28916HgahVUZJo0yomwRV5ehyqoi3tv6fQUWVJmBuXz/erxJOXBFNBqfoWVxOwgoLeaaKEXQusKDKQhpyQyqqrsDcn4V2Wk8k6Hy2Ilct2KpMj4pcLjBDg517NDTTIpxUcHI851FlCCFKGtH7lurtpGZxyAwvEqSCMqIiRBQQquJTY6ifYc6yHB0nfOq8J96JeFeGIcPSBaPbZ8F9T3WUnmEpPHq6x55z28WpH4JrZtf6vbfpOf1z//5P+f111/n8vKS3/Jbfgt/6S/9JV5//XUAvvSlLzHPM7/zd/7O+vy3336bH/qhH+Inf/InHw1e4zgyjkvz9Pb29vQJjx2QjAedDCw/LJVPqKLkisrnl8fVgPNir6JchkNNS5xmFKI5VuimhcGjuo607dFeLtTQJZ5tj/yW85/lS/vvwn29WQLg4ch85nAHj315RClFbCzzecPxzY7xQhOtVEPzRm5Ce1xgj2Qgbf2yqK6sSdYqG8mkE5FdpUsvS6HHFRmkkdmwwjSLVgtjstUMT3fs3zRMF6Biwp8JW9EcNe0LjZ7y59yB7xOxzMVEEVHVd5ZwZ5j7xHw2YxuRG7I2sGnmqtaukKBWHZZzlahNgvOJtFMMTzUvXrZc/rym/6/P4cW1eKCdbzi+teXlDzjuvjvyo9/zC/zbX/gi3Dr0DGdflrkv3ypevGlln0i/KuSKqsxAFePM8SiwZ0pgmlxZqUSYDdqIo22xngfESbkPuQCX4HccpcLaddJ3m4Kp0Jozkb6ZmKMI9IakuOoPREqVJgtCSJq7sWWcLVolrAqZzi8kif2xyYPPM40NDJME3eISHZyuTMfkAuwkMMWoSRHGg0MdxBvsGPvKWLUHLZqUmZ0YtlFEdAeYjWOMCt8EYlDEwcKs0IMm7gLexjz7pSHPqwnsaisqVQJdvx2r6G8IOutVyrXgXMhwIihlZOwChA5vpamrgOZsqt8pTJq0Cfg2ynfJcmehF/hcAogkVgVx0DM1kdNe4XsYA5jRoccWNc0C2fVC4KCsTaUdUYaaU0Ld7omvPwGt6b5xx/P/8QnuAO1LL24RWkZg7r9gcfeZYNRntfqUUA7i/kDpvaumkX9KCRtxEoKG2W2J41grrqo8H5OsUwU1KoGw9MaqGkc4kXY6cY1/ZF1dyG6vBslXFDpY+mmfZUP1rWzf8eD14z/+4/yhP/SHeO+99/jyl7/Mn//zf57f9tt+G1/60pdo25YPP/yQpml48uTJyeveeOMNPvzww0f3+Zf/8l/mL/7Fv/jqHx5TLS7BqfZ8HildV3NfJ7NdZV9xkVkRiv1q/iEKQQBjUE6asik3cMtsh+pa0tkWfynK0NEJFHHRDnzoL/jPd2/QfaJEgBbAaEKncQdEIf3qkvGNDYfXrdh47OT7mBF8Vgyad1njrZc+BUmUNfQofk1l9qqogKecqOopkzyMSD1V08o6w5OIjSi3iGacEUv0XhE6OUYhfwZdvKE0YnjYyL60h80HCd8r/FZ6CiXI+kzs0LOCuxa/c8ybQLOdKrkB4Di4mjBoF5cgFmF3NhKi5nhouP51M9OF48nuNc5/xjG+tuXwRsPzH1JMr3maJwMH3xCvG8yhJAEi7hoNpKMhZqUGP9r6PtWscDIcc5avTNYInDWml8oxzGXBiuiGDInK/Jb0ecp1J30cn6nhcvkmZp1p5nlI2emEVZEpmhq4QIJWazyNCjgdeKl6QtR8sD8X+FFHgs4Ldq7ktJakQGXiiNUxK3kItbxznp2b8Pnkz8Hw4Ytz/BnEyaCOy73kz2Je9CRIV11EKUpIXgnjbzBS2RfGn4t1wLrvlgTUuVCTE6UTF+fikVYGmU0egt7vO4FvVeJw32JslCrLFCdvRfSqws+L3JQmeiUkJhehgTSIOk3KijpxlyrJydzLvOCMEDjcnSAIZszzbkFgv+S0BBZnSff7ZVkporxFms570jEIk/hsA2FG3e0x8yXRKeYzS//RQNKO+Szh7hVuL/ZHapikdz7PdR1KAVmXQpC5Mq1r/y1FTTwO+efSs1KkuWD6gYQRmLCMDmFOKP7wILkv8k6Z7l63V6oz9UoAe0VVfqXa8dDB49vZvuPB64/8kT9Sf/6hH/ohfvRHf5T33nuPf/SP/hF/4A/8gc98XXooOrna/uyf/bP86T/9p+vvt7e3vPvuu/lAq0fL5rp9swHltYTJZ5XZ612V4cCUUIVNtJ6PKPu2cnFHJ/BFdBD7yHkzMEbHzdTT3iQZHizq8ymRKWKkbc+808wbmb2JrkBz1FkqyJVNFrlVQ/ZBmnhFAy7ZFfqSC6FKfw/LvFiyyCBlVsFIWm7YeauYN4rQZ1jF5Kw0V23RyH5DUxYT+bsdcpCw2a23Wb5HEQXWRthyU2xIidq0h1w8ZihJ6VR/Lyw1pRPN5cjxTYMZDe7ujOGp5fCaZnpTiB5dO3P02VLdLAr49XKIKlPds039w8sgIdeYSXXBTNl6IwShAydA5WBRApZcz9SqYYU0nww9x6Sq2O4cDU7Ld9OZdm51RJPqc8rfyvCyDwYyjT5G8cWqM2D52BU4MiF9tt6K83NrPL2dGYIlrA3eFCxUVblgkkrooBdYeVz8r+SDZGRiVjXAxS5i20DThDoXVt9CiXBxUe03WQFjng1aa4yJmTlZhCEEaZCAJxAjmQgs50Qo/jEolNKn0GN+fT21gtnKd8wIY2xk/yq/LlpyDxgZx/DCtiUslUfynuLXJ+xDlWHrTOQoa9rsUbnPbofE3Ms9tYmrecvyUcvujfTsCstQaUUiJ9NJlHwemk4+Vu2k3H9fZl0Xq5T8pHIjnKJSy4k6rbY+Sxjim23fTH3j29j+m1Pl33rrLd577z3+y3/5LwC8+eabTNPEy5cvT6qvjz/+mN/0m37To/to25a2bR/920MY8GFgKk6kj5pUnsyHhWUf2jzyXPGrES+vRIq+kjmUUyiTae2zl5kLm/X25kRoBNZ7sxO4825s6V7m7CNbLJghoSd5zJ93TDsR3i1W57FJoqRdKyTwTzx4hR417m6htzfXAunFRpGsYm6yFJNJ2S5dKrOiqmCO0N5EQiv9OYEb5IYKDgleW6nyzJip9UnYiEkr6BN+k1C2BCbFdK5o7hLdiyjW7BvN3EulNl3K90lKGtZm0HCtmd5UsJuw/UTXzRwPLSHToqWCECZfEaEtZIb42sBd74BGhj4vIpurgxAsVGI/NaQuiIK5Sswbix2o825MmWa91nwsh9lGjBMZqVIpaBeqYoaxUZhwSonaRmYg6txzKjNKrhHKutaJq+2B/dQwe4EHuzwgvZ+a+jMgXmMq0VrPzo0cfMPoLVM0NUDJpS7mmZM3PDk71MeKn5bJwX7Ogc6ZwNaNxKTxSXMzdhzGRph9kxHCQ1CSFGXSjzkK5FYUKtydCDSHJgesmgwgAaGNnL1xT2tDFTb+5G5bz0lKisYGYoocByeDzV4z7RvpbzaBtp2lkjeRpvHSj4xI8Mo9OGUjTT/jZyuWKlleKmcUq+RUoEGVbWESiAZoFFJRbMWmpwgSg0DoRdHejonm1ss9GhcUJuVxpldYfCkKu7nvUOMswtKbnubaM28cw5XmzBUdVUEDquO5NdC2kshOh4oAyTrziIp7hgMVK5JGnjUjZlSpKG6sqzNWcF52fa8+hCcU90JAe0CBL84c6+0x6ae1Lcr/0Xte6+358+d87Wtf46233gLg1//6X49zjn/yT/4Jf/gP/2EAPvjgA/7jf/yP/JW/8ld+2ft/bDZhbSa5PkmnHjO8UtrWrWQKeZq9zkfEZcEo7KLK1pmmBY/ue/yuZT6TKX60QF8X9sgH0wXXdz3vvZhJ+4MEirYRv5+7AXUcmc+v6nBysCVwZUv3khUnhRo05qirM2v7MuH2MqtyfKar7X1ZpIUmvzAMQ5OwewmwZkp0L0XIdrzWjBfiPyZflrpohUYo9Xqmqo4nkzPUCMklpquU/ZVk/qR9OeH2nk0UE8n92y3jpeb4TJ3YX+g7gx87bl2D2WWGX+5HtY0X6GhoGOesGZjdeJt2ZrcduJkvSG3A9IHW+do7MjritpPIJc2a6BQhm22qVbWVCoU8KpiVzD9FEYT12EyJFyhOmwJTgVEKMtEgRS1zTF5DDmB1WDP3vj6+3VVGnbWR20FwWB9E4HbjJs6bgfu5ZWMnOuO5nnoJPiAkjWDp7cxlc+Tet3xy2HIcHXfHrkJuZ/1AaxYYc+MECroeeuyKyv7y5U5U2GdRky/it3qU2S/lhdAz7xYH7tCLVmSyCeVz5eISnAeafqZtPLtulKAUGtFCNLHOtO0Pbb59FPHeMYO8r1uOsTGisOFng5+yBJeXMkW7UBONErhAko247uvaWM+v2nhhUibEz2wytXpUQfp69k4kxexRqq3Q5EQviPyYmmO161GdKL7HYURvNlVlXikFrpW+1DghvSsHXYs5euxg0VPi+EbD9AT8NmLGXAIKvz/3zXKwKAEnIOzDvkdZKyIjRRw8ZgRHpUqzr+0OFsSoPKdoGZ4YVZbefX7PupW2TAyVXCUH4JEKrgwnx8fnv5bkcDkv3+r2yw5e9/f3/NzP/Vz9/ctf/jL/7t/9O66urri6uuIv/IW/wB/8g3+Qt956i6985Sv8uT/353j27Bm///f/fgAuLi74E3/iT/ATP/ETPH36lKurK/7Mn/kz/PAP/3BlH34720nTcTUBvijD52big4P70PfrsaB4YgJnzKJBppRIsYQgtvXeSyO2yTMRSW7SjZ44hIYYDOZ+yvuyJGcXsVmjF03AlAkUpUKADPlpCAi7b5Y+Vglc5YarUJ0lq2okWZwistAqJUREQ51vsUPKChVSiWkvGeEh96uKiGiBHu0hEVpFSInUq8osREmVGFppRsdGQ3Y/Nj5krUFQXhT2Qw/zVmSlZOBUERRgkvSZsjadNbIA1uHnLBVUJJnunow4F2ic2NYPmeLtinRQpltHizjlmFwxlJuoLHpJsnMxb8w/R8Ql1yQRz33l4lBVFaHMwmorvbrktRx/JcHwcN0LW8+JZNJQyBdGyBchae7nNtuKGAao0KdVkc7MNNpjc/W1sRO7xjH1poovFIWPNg8uj8FiVeR2avn05dmD61oJa09F1GhOpj+LsorIjlHZq0lLTysZgcTVxtd+VJOp8QphR6akKrOy3HU6Gx0mEFHdDOUpIz5vYdJMh0YYjkEqpmTS4nLQKFS7UpXP1yR5Dq2eoDzUXJ9Tfk5p8bCLQkIxg8IO4thQkjPlkyi1VKQioHwgjaMEmVLRFHuUmJ2Pkb4UGTbEOZKz6DlgjxF71IJstInUxYU6P2S1mJIorxR8aqBZqduvn1PbGFWUYZWofzO47rPaLRXFesgbeKR6ekyZ6L/x9ssOXj/1Uz/Fj/3Yj9XfSy/qj/7RP8pf/+t/nf/wH/4Df/tv/22ur6956623+LEf+zH+/t//+5ydLTfMX/2rfxVrLX/4D/9hjscjv/23/3b+1t/6W9/6jNea/vlQ/X19UEt5bSBNpxTPJeiF04uBpYJLFVmMklVVuZaSjmbmoRPvn9BAZQDm4OVUIEXQ90fZl83BK4vNpsahZwkctadQ7r2sfKFmkbUxgyy+2sPm0yiVkRPITnQQJXDFJi7SP/lmF0kpCXB+Iwu5mUT5PqkcvOYkWmzKSL/IZjPGBDqI0gbAPAuE5PtUF/3UiIVKaCUwyqB0Ikwad+dx9572pebwRsNwJXClOSqUTSQn0TJlN9yoU1WXKP0wlZllSok0klaJZ5f3dXh3bT/S2VPfoOgQoWJDhY1EHqJkv7mimPXKNkRluDhXVeXSs+sbW2FsyPM0Mng9jQ4fZOFWCJxnXjjiJpK2nk0zc529vvpmFnq6t9yFlm0jQ9ORhsPsaI30jhod2FohWtxMHRfNwNNuT2tk0PkwN9X00mSSRoiiXD/OlvhxV6ul1EZoIqaXytYf+iUQ5ExFdDXTuoUkl7WR89M8Gdh0E9ZEmQlbbp3a00oqG07mi7ltM8QaNKqn9uRIinhjpKfm1YoRuMB4ZbA4nANtQNmcmIRMjc+/KyUsRjJkCKCmAn0qcFG0CCeBrs0gUHhzm5OQJBWXyDfl6y4kmGbi4SBVTCP2J+H2frkMUiR5SaSLzilKQZ7dNMdIs5fKI7qE7j2xcZhB7H7wmZhR5J9Skmuq9DLz/NeJwnxBgHJvjYeGj3Wea8Uq/AzJp5P19KTftep/VYX45T2UUfyibMLvYJD7ZQev3/pbf+vpQXuw/eN//I9/0X10Xcdf+2t/jb/21/7aL/ftH93Wg8TFf6tshbYpjctUaaIPYcI0L/htpXrG6TTDqBeIsHuqUG98cBFYK3MiTjHvFOP3Dvzgex9wiA2t9tL89wG2WxkmHiZU6+qFoGLKgUNVZl8RUa1ECy9wRv9por0WeajDM818LkEzdKkSPdytqc7HflcqqMR0LgK8hS7st7ri7u5Os/kksPuFge0HIl0VWqnyVJR92SHRXgf8RnM3Gw7vaCF75JsytuC3GeU0EKxmfqIwV6ZWdUnLgtF9KkSQ0GVfsgj2pQxaTxeGg42wyUSGoLN6iyz4AMNs2TZzllOyEsRylaZVomm8mCHO6/OJSG1Bzb6VV8Q24V47Ml23KK9hUmLP4cVC3p7noBIUcTAomxaIMCmUjuKgkX3CdBMIB0vqkB7ZW4O8n41ZdUM+zuQNr2/vuR567gepvJ50R87cUHt8SiWup56tnQhJsZ9bfDJ0Zuaq3XPVHLiZe16OG96/u+CWjtZKYLodOyF2XMwyr9UGmtYzvewIR3F6RqXq16YS1aVAZR3AwholCdzlLkZ2mwEfDEMWDA65ojI6cdYPhKjzOct2KTkRCd7gRwNHk8lGksC4+yJJlqQHmzfp10oAC41imhShN4RNQG+8VOitrwzQlBMR1eZ5wqM9SQbFdhowS2C0R4HQzRgxQxSrEqcr7TwphdJZbcIYmGfiEJdAoPSpHqGSflOKEXV/kAB21RMaYekmmwev8zFVPorgQdZQjNO8BBu1+hxplWRnRKm0ONCrZb2wpQvSpFf7Uq+u49XjMKtqvKJPWPdbgtwSJJP3y+NLpr/s4ztcnf33oW1YMo1a6i4naMF9OT0JK5ZgimssdoEO674faTBWdhFQJuwL84iYCI3YmGifSKPh6B0bPfG14YpwWAW9TH3lYluzG3Pw6NAudhQRSIqkI3rIfYgA/ScCFaoI44UmtCozBHOmnCnsaxsTM+asWeeqzApGX7QSVa74pgvQXtPetLhDRHstlVcWgE9KsX9D095KD81MCXejSE4GgH1W+FAR9CSEjeJHNjlVDf9UADKUR8q05CiVkV5ZcsSo6qJXSBFivyHZvQzv+orJ68xmK2cuhDy/lefNVL7Pqjo5y7FWsxIldo3AfX5FB9NJhF7J1V8rvRelhX4us0jiTQXiFtx2kaOSRYrMnIz3jgDc5grN5FmtKRicCdIvmhy3umWKIkZrja+U95tZspqtG7mZevZzkyn2likYfNLs2rGyFZWSfUsQyai018zYnAiVB6mBCxaouMKH+dqKfcDsPE3rGWcn393IrN5+bOo5mLzMrc2zmHYWDcRhcPjbBrPXmEP2hVsxYCVIZsJSDjhVJDqSk57sguCtGHM2EbocqPK8ntob9Gzr91MxJ1JKznPKcKXOyV39zhFBQMYZDq+SEFTTCMIye5imHNFlzRE4cbVIhyAXuNZ1P9EqDm8o4nZGJUX/PEp1FyOMY6Wxv9J/4kEgO1mUHqBJ69eu1rC1gO+rknoP1sq1NN6jRLfVvh8raj5LF/E7sP33EbzK9s0mwNWKHVN/Ln9SD16yKpUfnpA1VXQ1Ua5sZkOWi9NpYgPuDtSo2U8NZ+bI9dxLxpf3nbKUDEhAUEqh9yMqbE4X1fyzDlTn4s2nIVc5AhXGQonPivMAesiBS/gCVXg1GfBFrV4l8EKRV0r2HbrENCvGS4vbB0mwco8jKQl8wzNFdKoypdy9ZJLRyQyaGWSOTHsRevWdQJR+A9FKhWYPqmovlsCp81pQmJbV6j0qjJGMvfg2FeZhSqrKLsECl1Ul88xQK5CY9qkq7S/nNv8XEMadjaBypemlp4dNRC+yREqLKn7ZrI1YE/FAioXpJ5YqRaGjULh1ViOZWse2H6tNyBis+HK1A3fHlv0o+oiNFZagUwlN4nbqaEzgsjnw0eGsGlJGVA1WF82w0OCTYpxtrQZFN0mEektFX/pFJWGo10ZaRi+iTcRNoL0caBqfB6Nb2la+e1H8iEmC+5z1If1scVmBXgSNLeZe4+407k6q76I8EfM1VvQ3C4pZgms5VyIcrbL2p5ZJk9LbnEX6yt1p7L1UjaWKjDbfxwmh9DtVg3PKQbNeSj6Im3cWL6Br5X5tnOzDpNyqiNKSUEpIG8Ys93h2WE7WCOKSj+14lVB5sLu5W1oQJ/NX2Zm9XqIqvRq0PmNb9+9P2YNlTXQUePCEcQ2nweYxVY51K+azKrP1vk5e+p2xRfl8B6+VIsZjkT2taKsnmUR2Pq7smfWcVlHbAKl21gSO3E87ma/I76PKidcaLnYyBDwm3DGhJ6kavqf5mO/dvsZP7r6HuOvQh6PAD11LdEZcmDO8oMOTSpIQ0obsJylZ3LsXifbTifnCMV6YalQZG4Eg7J0MApsJsbWo2WQeEB7JOodpmf9SZOdkWeRDB4fXNE2n6lAzailS/S4ReoES7UGsUvSQskKBor1O9M/luA9PNMOznDnPYGZViQHJZMjwLJMClLDbxJk5v5mqHyufeqGgh6To8pDvWDJwEOgqr0CF2OA6j92N+F+4oL2G7jpwd22EOdcmwlbGC0r1kaz8b/cSpMMugom1CktJETJdXunEnMV6tYlsd0Mdmr3LvmDBy9/TrGmOOaHI803jbBkm0RHctBMX3cBZP3J3bDkeWlwjdHOjIve+xUdNaz2N9twNrahRKDBqz8ZOWB25n1u+9vKS4dCQgvThUsoU88EsOpkqZdkk6e+pPPcXu4g55H6lz9T4XWT32p7G+rqGdm02l/SGTw8bfDBYI751N/u+ivkeDy1h1lVmqrBWm7tUZ//MuFyrJJguVhWDhpghZXcniVJohQEbGyFzqGtHahLmqLB7zebDhD0kzJwy4pC95iwMT0UAILqUmbnSS/NTfjNlcR9E0jwLGcs50nGQpDVEkp9kYDgHG51ZgJTgk5kzqmnEF8xZ0ssb7P0ZdmhorjWhb4hd5Oa7LO5g2Jwbtv81k8GK7BQIVBhEDHctnrDWW10PSK9p76LTSt2PTJXHk30BKCv7EQ6AqnBjekB/r60Y7wWGfOi+8RkasycqG/9HHFL+/+mmCgc8UQwoi+jkq8+DkzR7rcrBqtridIjvpCorvTM4kU8RKRapppSzxMstKshifv+Opnnvlt/w+lcZokCHtvGk1lHx8L4lOo32BmWN4OIxLyIrjL40sOVnGJ81TFvNvM1QSJsV3qNUW3oWM0E956os67glQ8b5F+pzgYYgLwYGaBPzmQQhk/XhQicVE2rJjkOblgolKvSUaG4T7U3C3WWfIqjzYWWOZqHwZ1TFKyKJ5BaKf7IyItC4XHnYwNT66u+kkCrLmcBxttWHyxqxl7c6uyI3M1pHztqJj9oLqRTvAnq2siCmVI9vKmy1WUvFVRbTIEFT2yjzREEGY1VmwYXJoJsAUVTla2WYB5oV0vPSrWd6olFRYVthRcYoAsRdL2aO+6EhBM08ierH+dlUB5kHb+msrzBhUacHGLzjk/2Ww9AyHpxIYo1yrGo143KpG7Pen1uJ1EZVz4u5N6CFeON3EXU5sd1MbNuJ+0HU44t+YqmqxtnhjCSF14cepRJNEzB6XuDC5FD3IiVWtASBWt3ZYUEizLhUYyotg8PaJ7zLyclRETaZ7doUNETVGa2ymSnV6y046a0lrer8ZDISEFFyTEKnSbsedX0rlHdjhMJuNVgDA9LLKmtICLX/rSSToNibpHlGHUfRKsy4bRHR1tuZ+dzi9tLn09sN8SGjkFUFVYhnaR0Mln5SionK6yyqQCeEjofswfgK0aK+j4KTMaPP2sfD7ZXg9GB27Duwfb6DF1Cag5/pRVOfdmpUuVbleDgDJlIqq5L5syij68+gcpZkLbHNDqcBxqeJ3gaOwfGV+TW0ilgbic5g8pByaqx4UVlNMgaskdmaOfehEkIXztAdyI0+7bQoX+TKSG7AhMqGezpIA1rlLFV6TixzVSzwiIosqvRtvslzZltYV9orYqBWR8nJbJOKiqCSLJIB0sr/y0yR0OsatE6s5EsrKQcp/Op76OwK3ST0bj6RXZJFU2DEspXB1/Jv9oaumevCXiSYztuBDzKpxAwBe4SwyR9pznRslQd0JxlFKLClyoOxyQjrUBonUr4klRZKdiZzlE3mvxTaRLSRvti89aSosFZ8wVIUAWBrogwcj64O3Sqd6JwwCWMQQ0uTIVGfF4SiTvE8bTjct8S9Qx+1DJWXJCjlc5ry+SjEnzzUKz2lrLCi5PrxXSI1Eb3xnJ8d5ZiuFDzKrJtCIC3vdYVqvTdVdURg0fx9VwzNlAOFJDZyXmtyYwROjC5BdhNXpU9akP2QZ8sLimBFl7MKUOc4DbnHmkRkOilJLmMjlVZoUxa5ludGowgOQu+wK9FdjJGBYwxM05LEroaWIQev9RaiKG1YU13JUaC6wGY3MvZdpebj3NIfe0AGq+tSRn9q4EqnAaX2vOSX04DzUDHjscfXykGqeIE9RLF+mT2sEmAr0eOX9/KH2+c/eOWtZg4pnZbP9sFXrCd4zbrRwix8dMexTqfHcawnu5TMpSmqnD2BEmMxanzq4Wcu+Rf/+ZKf//VP+c2v/xzOBpK28vnahtg7yS4bIwaw44Q9BNxeUmBzVHVBL/2hZGHsNX4jASY6oY5TGu9KbvT2JrH5xgBGMe8s05nJElCit1j3p0UvMbQ5E87ZtyhhLHCLGRV+K0PT8WKGQURc9ayYnghbMNpc9R3zrBsswcosP4cumx4W6FJn114bJTD0AdsGznbHaqNxu2+ZB6lGlIJNJ8y/YhdS6ObHybEfG1JSvLG54zA3OBNotM89D9BT4OxrUdQ/zhPmqKuhpt8k7FEWudikejzNjSVU4d4ErlxS8lix7wjeSG9Oiaq67Ra6/jRZXLf0f4yJdP3M0+2B1ng+3u94MVnSwUET0U2oSvIqK260mbxx9I7JW/a3Hdw4wqCxkwQhv0n4TZQq6pArnRm0KpqWqsLEZYTC3YuSfmhEdNm+dqTvKaC+cgABAABJREFUxDH5MDaoOeHaiV03MuZK93w7VHKGny3zKKw+pcRJIUbNYdTVkNI1nvHM4ENO8pLC7nMV5qQqKtdM/zIQGk1okly3jZAdkhVIvJCP3F6q2+hEMk3PWQHGAFmbUCVBApICzi3aJ0ATreL4hpCXQqtqQhUaRdhY7MUZ2lqphBqxLVExH7c8EKwaJ2tCRnCin+r6ortWLhLvSbsN6OweoTWXV/f86qcf87/+7IUE4jlDjUafDBsrY2SsJixV0qtkDsAYtBVfQXlehuhO+lc52K36VsUq5YQjkLL1E5wGqpOqKr76+MOgtlYs+g5un+vgJSfvwYNrDFafKiOvRSFPymAfH5ycItib+2NZQFdZl7MYuQAKrlwuMogwRez1EXPhSEqje4+eLeao+OqHV+zeGnjz7I7hyRnu8lxIGnMgbRwqRNQ4k9qG5vkBHTr2b/ZMl7LIqyD9JTNIReV7VYMMSZGQzK9AJUlLL6mqA0yR5iU565YG83TRMJ8Zjlea0JCFaxXjLkov65jTxLxIlMHp2GSdvzb7KOVMUVyj8zC01oTGLcPPowT0qmihcsWFfLdoRTKKpFCbgO2k4hpnS1srj0y8mDRMmn3X4GzgshmrekNIilFZYlLMQYusUjCVNq9n+Q7zeYMZE7uvJppry/BaqvCqSlTNRtKi96hiwt4aYXO6iBq1DGEDetDMkToXVhTpAanKtAj77s6GavcSvEFrYRq2RlRBZm+IXtNcDdVZuPTvQtQM3nCcrQStu07UMUaNGaRSLHBrstIn1ZOi+1TR3MjifHhLxjAK+UZPQE5OhteCQG9t4OrZXWY5RrpMt485UXh5s62uxocPdnJOYw6Skbz4J45PVR0kLmMFykhADRtZwFUozFJBDEKp/BXMG2GtmglKVqZCqi4L0UpfLKlShSnCRu5rGceQoJUyQ1YFcRRI+8DhDUcyAq23L3Ttvdohj5koEaZuOhljSdsOdZxQ0wzHQdaHpqnOydI/ikJvt64SOIrnV0oJdRyJ7SXDpYyLvPz4jH8/52Cfk8i028DLG1l3/EKVTyGzGDPMl+KKCViWr0KjX/f4rXnQ7kBOVgxyRNezXXUouiBTD6DLh2rz60C26m2tafPK2UUJ5Feo8rJJn+rVwLNQhXgEe/2Mbc0ifCjYW8vqU+wXoFoMrE9oZgclrYh7i+/BbyL9duLCHNm6kdudZls+d4TQa/SkpaWlQQ0z5lbT3Hai5t5KZirDyWmxRCkfP3HCniszJHOek1GTl5u9tZlNJoEmWYVvFb7PUk0mH9JA7ZmVSk18ucp7qcpOo8gEZZJD6EUTz+d5IV3g94hAblpeV/tsSZ5TzDWFDakJdqHEA1J9TEZEYLP6e8xyTHIqUn2eNQEfhGJ+PfTyswnYYi3SwnhpUVGy++ZekawRE0IrCxcq1ePItCiIlGOTkiysRWRXzQo1GqlmoFYzi/IDMhu2W0GKEebZcNCOa9tzmByHoYGoKptP68gcpHLxUVc4bhxzT2tWVeVdBeR8gMxmjcLobG4S7V3CzzDvVSUBSa8xf8bEMrTcBpyJQhgZNQcTM1tSEYLCXzfVo83dF5r7Mt6QNKge5tYRV8ehzogmpNLO0mfFJFV76vUCUv2YMWWpsnydZIhTzzkBMizYoJJrqPS7Si+vDMmrkFA+YkZVNIcxUxKPt0b2p2KS3hTLcDLOCoQ4znLvlO9hLViL8n4hQubKqYoX1C8TwDmi0RX1IIgRqypJodPL/vNiX40jKYuDZu2EcUJ5rxChrGGvtFNyr+wVtt+6fbLeToR5HzAMH9EwVCYHwgckjV+0R/YtbJ/r4CUn90FJmtKCQT98ul91b4uoJasAVWYaHjgsp4zH12wiv08R4VTGiLJGLu2JkdjIzbD5imP+tXt+6J1v8H+6/BrvuBds7MzwRIaTAbjcMjwxkrkeZ9QoE/b6MLL7wBOtxW8kgNiDsLPalz7rFy7V55J1A0hldnxdkX5WiYLH7Jne3JKsQHvjhWG8kD7YvFsuxOioFObuRWI6U3lRL3YmkIYMCZZFo4lwZ0k64c8j5l7nKksgoaRVhgoh6YjKYq+FmVgo8rIpwlETes20CVy8dUOIcpOzt1IM6awOkUSA9n5qT4rws3ZiDIZxtnx0fUbbzmwbaI0nWZjOFUkb+k8j229MmPsJe9wynelsCy+CxKGTz2yDDFz7TQIt8CmDHKuyrqgI+qiQ6iBXAAmWJgfgDcdjsyjnR0XcOw7aMQ4NYZ9vyaxmElZ9ruHYVN0+4yLhaHG3esUazJ8j93rsBO5W4e4T7W2UHugA/cewfzsPs28jHJbhdEzuJ3rN8+sd/qZBj1rs6vMsnorQv9Anc3pFA9EOGd5rc6XzqVlGM3YxuxvkxAcJ8P5cKjCdVWPcXvYrFjoSFGWgPVdOM9XSJjRL3zYagXhVlnrSsyR4OveP9ZRQIaLngPYRHcRTT45Xqv1WlNxrKkD3/p3c+1ZIEqJ+kRV2SKjGCXnDBzgcZe0wRvpWIGtEYQx6T+oaolsCit54npwdeDlvxXW916jDUPejrbQrKhJU7pDCfn4oCUWujgqZ4yTwnaJPj211zVsPHH+W4nx9UX5eLF5inAoIP1TdeCzwfQvb5zt4wZIFnCger7FbtVBL/VwP2okG4qqsXWckJ/vR5iSLqYGw0FlXc1t6f8QMKSvFKw4Hx8E3PLN33IWegxe4Ik0Tyjmi05x9ZUD7zFQaF2WP/v090e6Yt4LNu4PINoVO09zKjex7ofyGXnoXekKqmZzFqpgI24bpyRkvfk1TGYfF2qQ081VeaFUQxQsUHN5QzOf5xiaP3mTCByHDltmwECTb16MmZpFbPSn6l5GYKzwVVPX3UkF6ZIXd1r6QYOE3aalaZs0nH12IDFOU72dvjYwEnHs2W3Gdvh1abJaFUirR9ANOR3x2Qb7aHLlsj4zB0n2i6D9OtHcBU5htraF9OdF9KhBPqU5jY5jPpCc5XhiOr2lufmhGdZlActNg72VxL3NEyVK/P3moNl4E6UcGRXzZEvqQRWOVSBwViFEBVqxEpsmglAj4zi+z1EoTefLaneg26kj8Ls92M3I8Nsw3Lc0nBreXpOD4eiJdJhkMvzTMW4GXBL6VHqm911U2LBnovt5UpqcKsLuW5Ch0MuBehojdPlVSjjukrKOppE+UrW9AKO3ayzXlt2YxPM1wcamcRDlDrovhKleMWRwXZN+ifJHQPhEaBVaSHnuAZFUNVPagaK4Rc8cAdojyuiliDjNqkoVZ+61A5aXPlu8D34o8mj1Gpte36CGgJ4/99F4SzpSgbYR5KJ434tvVNjL/dXN7QvBQJpM5Zo8e59zPtuIPlsRVIDYQG/CtIl5sUdc3pL2X3tm6gtFa3jdmeNJZiKeQ3yIRBRJ4XA1gafa5h69P4b8yT/ZQuLxCOaXFkpbWzEm/6/TnVxCqus+Qe2C/Qth4vBxdP7Yuux8c8DrDpV5tVD7cx4IL5600IWMiEZaMJtNi9Rwlm81HOCTNIbZc2XtZZDWiNA3o0RM7R+gsaeuwRkv/y0fUccIMwpCKNstGecko3SE3F5AFco6yeCQHMcNzEsjA7xr2bzrmLZU9tyZQ1J5WFFZh6FjpHi7XWehT7S+oUUvfJ0nASiYtijNxmf8yo9AMjV5UEcpCETpq1dXcJOJBFtfK+gISmlRknZJk+MqAspHzbpQe12wxOmEy5jRlbb+CgjgT8Enz0fGM7rko6Nuj0PijE/sa3xt0SPVFZo4QEs2NlITaN4Dlxits4+m6mbujRXldh78lMZDenUpqod7PuYlT1oM59xQ0lIFnpZL0y0DmoUaHaiJF5b2wHe/3nfSiXODybF/V4v1k8FuNzq7TyYiTdbKp+qlJ5ZTq7Jaey7nITsIjUhVpITyQr+HQJNxdqeISbh8yWzHS3EyEzuK3lvFSoNcC3ZETHXk/ycl0BDWu+tVqVZym/LsRFqKdxTtPJbCHWP9eCUAZajRH0FYqfIEkEYWOMeLug6jW5PtJzR5ipLk7JynDvFFVqgyguY+YKYqOIeRedJCkMgcrwmp9iCmLcbusVmMWJ2OonlxoDd6j54CZEn4LTTeza0ZiI6iGmSXRtA8Exsv2inbgo/Ymqa5Pr8CGKUqbY4UypZgqQ3R50xXC9EtlFVbLlRWD8bF9/ErlRQ40pwfms8zOCmOnHNgTB1H/GXhsmR9bXYj1rQtbMUVxLK0+OAmmuQp6lhmWORg+ms/5vvZDtnaSm6trUMcRfXtkvuiYLiy+VzQbgznK4mr3gzCTbB4uLtBQTLj7BQd3B8le/UYxnUNqgUKVTwm/NQIV9Qv0h5JFqcyGRZsXEA/jpTxeTflKA32XFbe9wniImXYtPaDMXssD1e5eZsTI/QbI2fO0qt6UULndHvoXck5CqwmtltdFUexPxWsr5bk1B9pGnvV7hmC5U6JwUogFn95vsXnOCsAoUVb/8OaM1z7yNSD5vs3q33B4zdbFMZrs4XQX2bx/QE2eJgc2e9egnyWuNkfu2x49u+ptFjKsqDJ9vhBq9DH3wjTyd5/dZV2sIvZKJbQLxMmQjkaIIdtI6qJYeAwKPWnCsSfuAuYi8ObujtFb+mZm2liGWTNhhSlZRhASKCvHrZpJTlLdmCPMZ7mXmkccQM51c5OqVmbRFexeRnZfPaBvj0IZVwr14gZ9tsVcbPD9RkYq1mK6tS9FZbfWKi7znGJLJQQVm5xQFGoCqJBobmd8Z4iNKLJHUyr4JDNbJgtNb3M11Qrb1t1O6JuDqFtEgc/T4Uj7/BJoJdhE8qA2dJ+MhM6QrEZPEX2YUcMIw5ihukjyQWYyS+thHKVnZLMMVFkzYoJ5rCK+KUog1B6mi8TFduCyOYpx51FhDxG/sVhr4UHCfDK/BbziQ7hSoK+vK59hRYkvOq+6a+vrq2BvUsta+RkiuyftlNM/yHs85vO13r4DgQs+58FLGYMqFicrhuAp+eLVSutktqH+cVUylKBlTYYaFTKN+2CQb83g8cIw0r2DviN0hmhh943I8NTxtfYJXzx7wfZ85J3ump98mmET71Ehcv+Fhnkj8IcKWTW7M+jDBj1FVKMZXjOZuaegAXsIMhAcIvNW09yL1mH7UmV4KNJ/MmOe39O0hubGMl1SSROxzYElN7WlYqBm7aoMsWaqeKGzl+lg7UEdSy+rEDAkMLpbea3fKO6+aOtiJTAn+K1ieC3RvBTYx+2FxmyOkpm6u57hqWE6U0znuX+mxC59uEqEJzNvX91y9I4xCPPuODmO1gutPmpcZuppHWlM4HZ0HO86qa6UImlFcycLot+YOipQWHjtNURrmDc7kcEaRbS1faHYn/d8CNmFWRbj9jqhvWbeJcImkbq0XFLFziNXnbEVxh1eypLotQw+V+agKFqoWWGOlu5TRftCqp7NByP377bcfM8ZX/s/z/zIG+/zWn/PJ+2O//2Tt9GTyhVTIm0DKg8lh09a7FGSoOaaOpR+9guiQKHnhD1E7DGIQKzVmMGjjzP69kAyujoCT+884eUP9OzfUej5Kf2nCXcv+3EHcQxOhVCQE7l5u1Rb807VkQWROJOgpsdc8Wk5B91NQI/ibhCtBEs9RbYvPNOFYzozDFeq9pFUhP7jRHOXaG4DzfWEvh+EIegD8fIMNOi2wXx6x+Z2oPu4JWxsPVcqIddICJj7Ef3ylnQ4yqhMsUAB4t1USRnxcEDHKNYnx+NSVFqLfva0Ok0wTqTWEBpRbvnkowt80LgnA/NuR2i1HP8sFZdiANOcIENl3dFNFvN+SNYAiriuyr5dayWONYt6YTKKesfJWvmYMG8eD6jr7IpB+Irs02cFqcdk976F7XMdvFIIwgp6ZGIcOD1ZOcCU7VGxycqmOd2PKMznE/0Qz1WSZSk4qc4KNCN+WmBs4Ko54FSg07Mw8orECitoZU74TuEOKVPcZ8JW+mK+WxhlKkkPoSwMdoxEo6qQqhkTZoiYUa4mc/BsPw7MZybPylCHiitFt3iHla+vqLBPWUz0sPiN1SHXuPzv9tC9iIznJcAlzr7mc4CUAHf/tiN08v7unmrDkqzCby3JNoROY8ZE58WiwndybO0Y8Z3Ge9E0nKJhzIKzguZolBI1Dq0SEcSGPq/UKQpZJSmBvJJRlVHm7rRYd1jqMGxSMtw9PJWxAXef6F4kkrb4Fzv6QdF/tAgkh1uF9orZwxx1DeiFtFB6fWrSQsowiWLZkYJCjUJ3L69rbhTNDew+EB80c/CY48zufSC1PN8+4SeHhk03oXWEPO9nRsXUSYBMk0ZfW/oPtZiVDonuZoHguucTBLke9eiF3KMUftfIzymJtNEmk2KiXFdn73vaOyPjA8eIHiNmjsxbWwNX1asN0N7mpMkp1FoMO62uMX3KIgxO5bmvBR4X1qpcXyIarfCdqpqE7iiwphkjsTPMz3Yov8EcZ5IzRKeZrzYCC2YKfbSLNY4OUSquKaCv78W7K+RqYp4XWLDIxQU5XiklkYkr604hbjROVHQ6i/k0CJElyZC0OhqGybHbjEybHb5TNFl5pxLA1rBgZgUCmVSh61pY155voh14gkxpVRPySqGvkN5qffslbCdMxYdV13dYkLdsn+vgJQc6nAaeR7ZCXU2eBWZ8KDa57mutg9Y6OGorEOEDOn3FuYuqfAgn2WZ0CWcSF/aIIeJUIHapzn/Uj5AroNBBswc7BLFLSZsq7RScKDHIvFXuU8wiJaWLsKkiBy6BpGgc+Ej36cxmpxmfKOZtroTyIYi5X1Aa9xXLyp+r/GqPS2WifCaFzODupLneXUe2Xz/y8ldviQbMDJv/+pLkrMjqAMdn5+hZ4e6kqa6SQESh0cRGMfe5ET8kzH0Q2NQUJfrE4Y2Wccq07ajlX5Kh5UKXt8UOBZGPKnYiqERoDc4o1CTNYzVLf6O9NSStRVR4NQCbjEBr0clx2XwasceUj3+kuRcSTXSSPJhB7FXKwDORylpMTiowTVYEMUnUU4KQXkoSAFLZttew/SCw+caAuRtRIRC7BvfxPedjADa8nHbcXAXU5YTuPAkrAbINJK9RR0P/kWb7QcQdxO6juZFELmmF+/BmuQZDlEDVuQqdqeBQZx3zmcs084i9G+m/ekPvM3OtcTmgKKCTKilRZ+BICXc3ExtDaDXOieNC+a7lGhTvt5QDCpn5uVRpepKqaN4Ymn3EDInmesZvbRaEFpahysO1804eJ0FzY9EhEpxmvJKqRSj1qVahKiXUIaFinrm83wvMmFK9tyuVvUg/PWQ3Z4sSlckayVliZwmbBmNMpezrEdQsGp2NDQx2gS4L0Syt/Qkf6BnKzytCxZrYUbbPoKgXVmDt+7tMoS+zXdWvK56umY8iVpGil3iCeq23z3r829g+38FLaU6o8iVDWdM0lZAiJDtaETbKfNaD6XPVtVL2F3kVpU+yGNl3rsAqXhzR216ekEU7CxRy9548PLzs+Onbt/jNu/+MVlE+hlIiD+Vk2n/eaKFlHwVCcy+OJGsw9yNtpraHrDBgZmhuQlZD0MSNML90kJtxPjPMZwYVLeNTGcY1Y+DsqxPdtWE8k30lkzPcRoKJwGlIpIrk+avlhtBTViEwuVE+SA/LDkIkiUZx832bTOsXYoS6uUNteuJZz/GdHdNOel9P/suM32hCI1Tt4cpUyajuJtJez+ghMJ87zBTRY8DcjrQvGobXRCJp4yYZRvYGaz1PNkd6O/P8uGE/NjIIHDTPhy1zMLTbiXnjMKPFGIHFktEkq2ivZ/qPJeD7reX6exuSle/Y3FCZmUlD/4nH3c1CtmmkP6GnwCY39JWPhG0jRIaNYf+GYXyqmM4ycQIqxdvemgyXCZQrIsuJ5oUEAN8pjm929Fqhh5nYOVQImOf3XH3tU65+0rD/wTf55Ed6/I/cM11KUE6jwdwZ3I1m85FAntEppjNRWtFBzpket+hhRvmIf9IyPu0YLw3372p8JjmWYG4PAo+2tw3dpxPuxQHGSWYbbcPh3TPGS11Zh6GVBMeMidA0snDH3D+7lkCajAQXCWQR3+vKAvT9EhRiMW5Qcv3NN4r2NmGPHns/k6z0Su/edahgMBnFqOooo2bqrFTeGnyra+/VHVMljTQvJkIvBJSW19GfXMP+QBxH9G4LIRCLQG9eE5TR4Jz8P+eKJkYZLLaCkNjbAWJEHybaa8ftdxnMG0e+7/VP+ekvv82TTxP9C4+7m0jzvLQlimJQSuCFEKF0lJ7VNFHNdEsVVvwNcyul/k2rCiMCJ2r1659P1TjIBcIakpGAJeiV/F5Feh/bqhh6+o7AhWX7fAevlLu96+E5TkvjShF9QOSoJ0ufBr80TcvJzRfJiZ7YCldeO5KmKUOSUeACPUe5QT8V7cEpKr56+4T9my1neoCLmVQavkbT3EXmjcLbJfNOWqOMRu0HjNWYqZUbL8+/6FnXxbSyrBSQ5KaNBsjaiGZK2EFjjhE9JvrZM+0Mvs/q7eV4eTA+LT5Kmjr3lDKDq/YqZpkb0l5me8YLocGX/YUmQ3Q/+p74mmk4PrWcfU2clM3g2b+xE/LFDP3zZbhbzwnfGdLOsn/dgJIFtHvRMjxV+G3AqMQn+y2Tt4SgaZ1n8KKsUYgbw2z5/7L3Z7G2ZelZKPj9o5lzrmbvffZpIyIznI0zjG3somiMrywEVgHm1hWFEA+WiickHixhUrJshISoB/NQtvADIBmJJ2QQyOLNwlJJFEndwuDrsspY9+Jr43Km7cyMzIw4EafZ3WrmnKP56+H/x5hzrb1POtMZ1q1w5ZROxN5rrzXXWrMZf/c1m12H1grht23kPUS8OAsZuhWVjNRJsCAWTpDbswJgqKpusAH6cwJlp9XaAKutNeoD8qoDe4PceQz3G4SV6E+OZyoumwm5ySh2I0VPUWY2XJGgQiNgDPcIuTHILxntpYHdMtzLLZAZeb3A+LFzXL7VYP+Y0L8W0alnGABV/2CM9zMuFgS3sVNVp7NJMwLjeiXJTZAEKrYqVksKrChjFK3+w5oQlwbb1zoAnTgQK6cqNeLZlsttZabkKDeo9iuiBm9gkkG2SulIkhDFhYIxNNes/Ks8tbZLpRQWhJs3W/idfMjkxZXbBElKq54mQTzl2qm9eDBz04qHGRjvN3oOGGnVAuY+aLMAffndKkBATVOT3LIGmKaR+7msBQppp+utgDs0scmdR1hbNJeMm4sWby/uAb1VzUUSMExpVQITWrFWQZjWmrp0cc3jixIQCh6gbDNh8bu2Ca2oFdaMJjR7EkoBMEc11ufXgDd7X/0swk1rDihL38j24Q5ev9c2P4GcD9CG5Xd5Gtf/z9E8BfZ5IOU/3+b95nnPOSVQyrCjZKn7R5LSMROCYuebLkwZDgt/pdyQJUiwN+BkYfYDKKTa78/qmVVaf7IQTy2Y2JkK/ijZvR3lxm4I+l48+RfpAjN5naAqNWQjC1b2mBakkpg1qJlraiZtxKKYAJJFIayccHaSBF23T7CbEezFnZmNVG5ul5CtLtae6sI/3Fd0YRQARVxJ+y0xoR89UpLzELNBSDJ/9GrJAQBbXX0tidJ8OeYiRWSQOovUEYYTUzlH3WUS0IEV0AkIlbMVToq/lUdzJS1ZyllUGNYN4tIiLQx2j6wQTztMQBAVj507BWTPgM5Gi2qJzADlWAIi8RTWDmZs4EJCvNdheNDi+lscrr4zAScB7SJU8jNYZop5wcg+I68z0sKJDmWSJMWMxbvNwPaorc8ikVXmc/Wc6xxKlCgU3KLzQTuWYMiV51WDnnacstPJFUGpGFRluEycKvkSuApOqvASKwnfYFLPIGBcT0CQ7EryRBPUXa/zqC3Isg+erX4J5T4CwsqKqPSQwY1BMg0sM2i9El+vzNOoAAI15yL/NLdGKio9u10FgKHxYCfXt98x3MZiv5Nsr6raa8XGRwHglvL7cYAoB9qQ3LhlPvYKANthNaWtv/pzfROxR5kHwVn78JYqx1dtU95GbX8j2x+O4HUMzTyaf82tBKo6MmbleBHcnb9esxyyJRvhW+/DsQw3IXML5wRtNI4wQ0SzkRbUxXcS7r31Ev+Hj3wWCYSXcS1vE5OQG4cgs5IRcFtZHMPKwO09cuvgE4NbrzqFuqA0wHCf4DZAe52xeBZhh4y4sLj8Vq/QY1kEi4eX62WhAlABEoU0WmwhCvjCqiFkalVVosRZoAbJ4VxbmL0s5tImkn8C2wfymRwfEwhmEMWO64+1om4AXbQCw+8yUmMwnDvsH0j7NJwoijEywokCIhqD1Mrc6GKzhLUZRFmIvMFioW69L7dL3F/tqt7hzdhi6QPOuz2uoHOOzNg/8mJ/0QK71ySQ2D3B743yfQh2NBjOBKzRbDKe/QmD/SNZsNlK1QKIDt9wroLMK8b4KCnfzQgCUCtjtlzwB6BI4BOxsIcRo0sOBhgNaGPF8yrKsb5sHGxv4fYL3HycMDxKWLx2hSfLfjb/I2wLKCRpC7jVZMhJwKZRroeS+Az3WIMPwe5RKRLZAWk9nb8KbYfA6J0mXOOJ8vJYADuA+KJNAVvRhHFCFTIBvpdEqgg/A6XNKG4FsIThTIOlFZ5ZnbcmyPxuFMJygeUXry49uhhPAL/ToBh135YQ9JgUSL0dpc1tdmX+SkitlfnefpSA88k34L70TCquEGFO1sAYRF0HAPeDnOLGT4kxM/LVNahtQffOtHuDA14bEcPfG6RV2RrksyXMSy/gENUgPRhxFGT1XDkeqBB4MtOyXjiur7JCmdCGs+R8PuMiHAicH+oaHgn3zj2/nJuCWk4AtIXJh8/7RrY/HMGrbEcDyxKk5lB6MpPeF8dYM4J59VX2JQd86veKqnO6dXKBwxPP4ygVUiFabgkXF2t85cE9fMeiRVAIFrcqyTCW4bncfJSAsDKg7NHcJDgvLYdmk3WgrRd+VjHVc4PYejRbrTDUNZZUCy41Qp7NLSGsJoQhoDe8A7LlOosRmLYsGNWd2QJQxFy58SiQwMJVJUPaX0BuGaFcnyQByA5CCxI5Kwar6kJ2slCMJzJLDCeiFgLoIs+yuBQwS1xphRkJMRo8ObtBSCJU24++nvvSQmQmtE0Ul+LoxEqE1Q7l5RbucYvEUkn4jSzSMsfLoMhohozmKmL1DgBDiAuDcD/CLCOSAZ4+8HCXdhbsJQM2AXBXtralBJSiflOWKxk5d8JXA0PknlYjlLKG0baAsdK2bYRzVcnlr++xWIzomiBqGwpIOVv0uGxXYOeU/E3ikh0maxSRAhM9P6/oSLZAUqRfamS+FJfi5VVI0kaFf+1ICGuVYJo5FJfZVmktZy/nPrVAWmRNigTMYnutRpVIX7y2oroSyGsh6i4z3zkzkgYaQRq6TRIAx8ohLidE4vz9KUvZaKLct6kRMV8B4Ohcl2ZBNlNV8ohLCxMdzD7CDBF8/wy0a4GLS/lA3oGsRb65kXlY28r9rECOMk7gMSBfXsE8eiCJhBEUpdsT+qsW9iTI3DMwUudgvQcbI/wxnVmRF8j8ZN80teMOiMEzgAd5kuBaEdcz2ae7lDDm2wyJfSfN6Fhl43hWdsf+OAHVS/EbjGF/uILXHdutWVeZV80JfgUpI3842oGiaRQSjzz7HbM+cdIsh1j+pq2B7ETxwljGLnokNvCU4FyWtoNzSvZEnSmApe8PNmiuIhAzYAtIQuHGGcC8pddQba3YvswNoIRZXVgdi8BvhCxYBsie60ygKKcDqAhD1sekpVFaXtICNSzKFBmsLULZR25k0CCZOklFoYvC3ICSjbTk5m2cuJDgx4DOS1iQmQyRVnIKMU6SnBRJKKteWMyEkA28TTILy1TV0DMTWpNl7kEAQoQds7pYA/5aqgkh60rbyIQsLeDNgLRuEVYdzCqgaSOszQguYUSH3AtxFo4B5ZGZOFmqmEDT8dPgRQTReTQQ/684S7xKQb/MSAvZL41G5j4NV5sSbzNGrboyE5zZw7URcenhbkThnTNgQAoSElRqCaqlYsqO9fohDVpA7jK4yVIlWkbyjJwIUc+r7bXqLhJOST2ytAIq13NuVIfSmHr7uL3eN3o9VERrnl6XOiCts6iVJBGRRoAKVPOUhDFkxhwJRd6sBKJyjyRFrov+ISEtUBX1zSizvdKKrMkhlzak1Qo6IS8bOX672aC4rDGKOOai+q6OyrVdVuD2SmnJDmiuAMChd7nO59jrWnPLWoQmgPRRECGLA79CeXhqBd7pd3gstFsf/zpae/OW5BGh+s5tPrP7Brc/XMFrTlTW318F8zzQMJwLVRboPXQ/+kQqGoZZa/6iBQZMPC/tNxvrEZcOYSk3UjiPeOPBFcbsYCnjxPa4t9yD24UghlYL0f7rRADXb0Q4NnvA/XaC2e6R7RLDqUX3MumFLy2RogQfrGS8bivw8/FMgQAN4LbCXYpLMXg0o/6tFe+j0sIq5oqxy7B7I4tQq8hIx4DPMF78qqRN5eG2FlZ1DVOXwS0DnVp4FB5ZolqVlcVFqihC/5BVpBd1/kUJSCtG7jLgM+wiiurEIDNAilIB5ETYB5XYIhaViWiRssP5co/d0CAkC6sBzpmMlRvx3jkhnHj49xRWnWUet3iaYPuCFCW4zSiwbUMw71+A28cY1wZtF2AMI2exaFENK5S5GCyQThN4Y5EXGbSKSDdeFDcAkM8QSShIm0ceBZiQokUOBhgszN6A749YnfYAgM3TNcxowI4x7KXaWrcjnMm42ndiQnmywb2TPS4B0MUKRk0xk+FqqVPUN7LOr4inIJM9kE6SCC1nwLQJZMVKxp5kWJthTcYYHMbeIewc3IWrAaharZSZlSYqBXwhJ6s8FwdzXglC4pCcOmA8zbDnA+JgRZBZrxsAamsjliXZE9qLIAR/NrXzUD5DbhkwhLyf5o9hxfBbaaW3F5K0TPqe8h6C6mXEpeiKFuI2mGH3CxHjLQLd1gqkPjPyZntQ0VDTVfAGW4NsTW3Jn35RaDXvrLwCsaQqgzGoqvRlPTsCXEzADIC6FhhHqfh0xMFM0lo8mu3X1xcov36HORDtoD2YU10XJz4YA5ymdqJiAw7W0lcFwQ8ILv/hDl41c6Cjh+8gzHEGOV+dR+dw+uKHU6HxCjUtGVPJog62Gd9CFKbL24kRnN0G+G0r7ZUbi/denCGdG2wV7+tMRu48rDWg/QC3TTj5CrB8ruCDlsR3iIC8WiAvvKgb6N8kOOkCkQE3SuDLDuguGOsvAWEN7F6fFgjbA4WwVYbVZjAH4rwg0VCkSJK1q/wTJ2n15d5KokkAmixW6dpaTKdJHh8NSPUJU5NBOjcqtu8F2DGci+EjGEgLILWqwddmmAcjFm2AcwkxWgyZVEyAkAZdfHuHpFVHHxxyNjhb7tG5iGeblajQQ+k4WQR7z9udzKROrMwWQoYJpqqdi2p5hhmB/esLQd8tCM3HVwpKAfYXC/FpM4x43cDujMyuHCuYQdtsr/XgqKoZQE0AOBlw0fazDNMmWJfhH+7QNQEhWQyDQ0wLcBQ1+YfnN6DXGcPgEfYeZIBx8HgaThCfL4RXFglf8vfQdQFtG6V1W26D4qZM0+9EU6XhdgTs9dwnkWDKywxaJJ0rSrAWo+8EazKcS0iLgHhqEXoHjAbhjGC3ctxzq9JWmvTk7GThJkETkiYq0p6bDFLDGSOuMngdwdEAQRIEt9VjphWjENcl6XM7CyZp9xX+YU4At1D1eZZgrbNgyqK76XRu5ndZrX+0E1AT2NIxYISzBmbMYNsgre7DP70Bbfcy6woROUuQLLN1QInGXVsBG9x4pE4EB9orqe5TYwSA1NHUFci5ognreqQJ9BRkzDSr2u+PqqAJqDF3yWBM6x5Yk8yyvhWASZwqurqGFgHio3V1Lk91COqgw5/nsPsPaPtwB6+y0SEi8HBuhakCO5KKmvvh3NoKeqfuJx9Ub3P0DKdcB6NTGQOdrQBuazDsHFZPRgzZI7BF5wKS0YsixAktyFIFeDXNo8TIa+ELuT3rQFotGxQ6nNX6nC0jQ0i+3ZUqDyzMBIVngtHZggxiJ1WBKv8EwKZJPDcnqnM4QEi0pZ2XVhA0G6tShGEBrgyqLDEK+db1AtZwe1HLCCuq87UCYCiIMrby+YxNQsYGZJ5jWMwvmww2BbcOWBIR3KImb4mrZ9dcbHTRBDQmYRsFBp0aIJy2AAFum+D2snCFtauisNvHVlBxTbFQ0VZUJOTBIhsGslQs8HLCuSlpu3we43JdMIsALrRFSEzgooRvEhbtiM5HuCSk6uulF3uSLAHa2wRqgZwMnE/yeLRyTtRiJFzLyW6apJ5RXOeFdpDWYS5UxQJB1wSIdCYs1agsOImc+KpZhmujrmFUj7cxDN+oUWiZUZZbwGWVpgI4E6jN2jolhJGQRp0x7qm2v9NC3J+5keqURwNEAZPUWWsBVFoJMtJ+NnVuJSRgqrYqdWam7enqe6b/N1rRzbVpy4ytVpBcXitaobWKVI4TGUJxmGAkQftBqhiECLRWvL+0bVaUR/pzi7CS66C6mtvbldccNTi3OKnrUUoHlNeDausu8nLZynpZAtTv1TL8veZjXwsY4y6y8+9j+3AHL86A8Ydw0CN15DrMxNFwMifAuMPsBHph6Amo/Wr5w2HPGaiwz8JbYAiwQgQ6hQDZbDP8jcW4N3i02OAmdcggnDY9XloCUpahbBaYclwY+G0WG4c+w4wR43kHdjL/Gu+5appnog7Eu1kfmWUYvXpfhXsJuHnTVJSXLbOG8nxz+HNRbZfvLLPV1IrSvAk6oFdUYXYGfBpgG8nM486BghFVeKOAgM3kQeb2GX6bsWcnskyjAEXYS2Y8KdJLJI3RwOgxNibL1eoy2DlZXCzD24SkX6Apbr8gtC5hAKqv0Vnbw5mMi2GpqEXCeM/BbROaiwFmTNh/ZIX9Q6s8JqB/wJOwbaSpOM0ki6oeI14lCdzRAC5LcBoNUjSwPqFdB4RgEQcHHqwEtlQSI90/AQsf0bqIxiY0NmFcO4TRgTPQBwdnpGXXdgGtD4jJYpuMulpLVeIuHYJjWDsgrQQkQZHg9modQlLliiWOtIwzCQhDZmIynyOtknlw2qZmpMcZJhkE5fYUc0oihvcJ2QrqM/ustwcjZ4McCZwM/HJUsBwhqLIIEsFdW+0GsPiLOZ2zMQHBCFBkUNmucaoWqzAvA+PK1ASsGFGaJMkQqwxXagV0UvQ3q39lOrx/SIsmaa2SdDxUz5NiFnX6KJURxwiEAHIO1DSyJoyQAAYA1gq52RCwXtb5WFZQy+4JYTyX80BKF2BDAgRx7qADVNt5VVx8Dt44Cho64jgIdADKbOrYwFIOxNcwjPp69ApnqO0DYMcHtH2ogxdZCzJFszDVE100DG9bVs8O4JxcB9STWYl3etBrACsyLWWu5bTi0h6vAC/sIXKRhEQZThm8yPjsi0e43+xw32/x5uIC7zz8FPzFKcy1nIasMN95/DX7AJx3WkFZbF8X1YOC8AJKW0N5O1F7+kuD7kXA2W/uwHSC/oHBcH/K+FgXi5rNRhFrdXuG22FqWTpCe62BNDH2Dxy2r5tq1sfBSNJPDHPt6nyreWnQXIvg7ngmCC87ELpnPYAOYIfxHiGuJIttLs3BXGSgDnQ+oluOMIbhnCYXAIY3pZVIweD96zWszfA24bQbMCaL7digcVEMLLM4EF/0C1gSblg4ZYQtodkQ/HUADCGcd7h4y2P/WAAnc48rtgw3yuIFK59RqiaZ7yFDKs4mCeSdhYgMAnI2CAFwLiPspIqwZ7JyEqQ6tE6C/+VugXvLPa72HbY3HRarAYvlUCtIIoYhkbta+AjTBCyagGHlMEaLMDqkdxf1umie7DC+u4LrAUokahma9dseIEfV9To7BjdSyRcTx+wAvy2ADEIYO4yrjPE0oFlMOqHeF06SGGd2ixFEjKGXjMl6aZfG0cFYATWRXnvwjHwSJMlgPa4sx5NHWxGKbicBuFRBBbg0RwkWmHxqqAYDtyXEE7nWa2tX75l5kEsFXKWcM1d83gyUQK1mmIwqVIycpSur9BgoZD4Pg8yjjCL9Muu/jHy6QOwk0GYv1JH2ChjOrdy75b4eg1R0vngqJeQZapCcm0YZBdJ+MKfS+dic3jMTLb/Tb2u27sljd7T4DkjJXB+7Pe+aA0qOAlv+YFqHH+rgBeDoBByZSR4NDw/EeIvvjG4HEPrjkwDU8rqU5szT8LRkSPV9vAMSwwYgLBUafOlwkc5w+WCBe26HTWrFe6uRVoLdBtjRS+W0NrCe0DCAMSC3QtYNa1mAShuvILrY8JTJ6xZWBDs6NFcGixcyi0qtUb6ULBQFaVbnIklQV91lqjcrW6C5iiJDpZ8jtahtS2QCR11BnHwO2xP8Tp6zfyQBqnz+5qYDZaC9SYjvWVFjUNBJsUaXGYxBWFrkzqBrBoQk7rCZRdvRWgkSpbVYCMpJz6k3GaEQdk0WDhRk9lWycztIFj2et9g/dOgfSrCiPDuWGtjlcVRyb+5YZlg0ZeXGyefiTMjRIo8W5DKMl3kRuQxugcVyQIy2dmm8jxM/PBsYYjifkJJBzhK0mKWadDYhZcKoQBRrRDXfWkJ2GfnJIChEL4oiw6JDihY8ALyavlNFeFpBnupFLeCGGQ8MQCUsS9VuEOExkkD8jWb2AuJhJGIRTc4kladTcIrOzOS2Ojq+BqDS6gWQohGR4qQakWrV4lRFQ5CJWhGxzM6YVN1jKTspgJTUobaiy/9R3kmPQ1Rz1DLrypYPUIekMloUGRSSoEmBaodSoelm1iosbTpNeJm5WrLUtidNslT7h1TjgutTlZc6cLKYjUEO1dvzrefUQHaXZNMxsvoggZ9lkPOAM8MOHDx2q9qaz7qOZnAfoDQU8IcgeN2CZBbI5nEpzXqXlHJ+DoEHDg/0nGw3N3ibbwr8OITQ62YtEMXQbjixsEEG4iZZjNkiwWCfvGZ6JDOv6z3sQ8mawwoACLknUIgSNFay+BegRSEFHyhj1A8toAgTDdqVh78ewbZBWBHGM4CJxbBQB+blNUWk1O5T7b1nS+IH1liMJ8LDSgsBVtRFPhMoCAoOA2B3MuMaz4DhviAcKYmjb3vpsHwvwt8krCCBOiwJ4WTi3RR1CERRim9cksCUZFE0RmYtbBOcyYjZICXhcQGonKciyGtNxhgdYjIYo4AnKHHlJA33HHaPDcJZgt2LK/IktaWLpZW5IkX5vky5crUwM5MkYjAInGWuJSr1gko0lgEXsWpHbNEgJSMzI5uq7VJmqq3BoZ+X17Lv6g6dCcwWjaqIEABrM+4/uKqw+cYm3KwDIgC2FnmhyVYQikNJYqjcCpkQiSfnAoWcQ1uMAm+XVT54h9wlkM4uiSRwp0QSmBMha9vU6LEpKFXW9uT8wi1VqLFZghzkM0mrejLKrPY9BupJJ8kY68wsLqfELntGXmapkPU8VfRjKS6scA/LfgFohTUFShNFLswOWUWcpZphq2CtItNUhLkrZH7WltNAREOqwCsAk1O0B7K2Mu0+ogIkZrysuXnk4fzi6PbXKqg6yL+i+3RLHaM+dgd0/pWCu3SrEKjPO6YdfcAB7EMfvKr8f7nYCpEYuDPrmNQ2Zo95d0jsK+xwzpVdbhovvI3Skmyaw4BlxH+nkJTNGKv1xM0nDNInevypj38RH+kuYZHxqNngtweGvRnANxtgt4f9yBmyd2AitNcR3fMRsEViSFpvFKW1E1dcK5UyzJaWiJhEhpXclGHVYvlMbNBPvhwxnngFIUgAMiwtJTMCICAuCJuPNIhL4WCFFVDEjYVEKsEIBqBRe44MmJ04KZsgbZa4EoJpOkmwWxmmp45x+W2E9tqguQ6wfcL28ULklzAFUjZAOM2wJwHLbqyHmBVKzjbD+4RlF7AfJAgwA7vBo/URzjK2Y6P8L/HyStngetshPFugGVRpgYAXf3SF/hFhPGWxiFGuDyt0XDQc5fNFBRyg0AcSAZlguihgEgDDpSjZUpsk4OnCmbUdRhDXZyKGdwnLdqxzo9YmxGwQk6kzMnIZ1iV0XZDgSxanXQ9D4lnWR4cheHibsFz0SNmgcxGtjbAmC0joocPVvpPqNFiEwYE2XeUVxW6qNAr/KrWCnBQVd6nEinJKc0lgYxEtgzqZ5zlXQDISRLP2gFOwSKoT23ZjFUo2Vlq4EuRKUCyJohzXUu0Vv7fYkVi6BDl3SZGBxKgyXNkz8goqwwXQ2QjurfqmSeA2e4LbSODOloBGPMgqsGVUwWJVm28uB5heAgpte3FiHoMEk2EU8V1rJtReSoBzVUKKx1GCIRHMdg/Kp4gLOZaj+pqlhfjwtdcZ9vmNBL7ZvP0ucFkFjc15qrOtgMgOVThwWJ2V8t/Yw46T0f643Hh4ZTX2SkLyV3nNNxU2tBqax6dilDY9oR7c+Qk8yEyAyoavZL8530HROjWLKlVduXA4TzwPQNoCAhGDCYqMkyQK95sdFjbgzO3wyN3gPy++F3nhYdpW7MGHBL9jUR53akt/f62abEBRqxDABE/VQZZhe3YQ8itLMBIrD8JNY+F3YtC3eMYIJyI2OxlISlYLaOtlIcEvN/p+DhWVZRKAkcCeEU9FmoCUHybqFMI1G0+hi4Vq97Fkt4V/k1qL8Z5DXKmMEKm01IKRlhl0Jv5Uu77Brm9qq9AXbUIAMdk6C0vJVJJyTAZEjDE6acGZjN3oEXoHuxV5qeSpVqhxIZ/L9lTJ0mzks7MTvpndGVlUITM6QcwwTJekU1IrCgAuw3cRYXBAJsTBKq9LguGoEH5rM5Y+oNeKMTPhVIElgMzJvE3w+h2L3UsfHRqbKhhl3Q1Y+ICVH/H+di1GnJYQk5OKlQneJcRRK702YjhNoGAmSxIuVQbV6pe0GmMCcicAnIJCdTsCG4eQCO39fW0V5mRrBUpWPnP5nDFaPYb6lqVlXR+S60TKD4B9RjgxWuWIPFcBUZT5Vml9psXs2uqyAi4Y2DtNMvQ+iWo/k7UV2YsAs1Ex6tJ5MJErQb14mtFOb5LilGwNqG1gFDyBEGTWpOrpxbSSmqbOxPNqoVqe8v5mupxFPHuvViwzSHr1EZxB5o/XNFnubnehblVE+rjuoB77WgQcB6SDwDNDXZf9vAo1aGYB9S5/r28K8862417rUXkM4O4DPX/uXJxS/1bROq9qT0IyGCJT4bWT2ry2NyIhBwNHCZ4SlmbEI3ctwIvWwToLDiPMKGKwYSlERRHwtFNrUOdUWUEExS+KDYOgAAPSlvxMaYBaVKfZ5kaCkfMyHzAq02QC5AY3mLynHNeKTgQaqPp/ybA9g3oLUhFeEybiaVZxVmSS2VCWdpooNRBSZzCcqvVF0aRrBG1GpyN8GxFGJwg9BnwX4ZuI1iWM0QrfKxNaL/M4QNqLMRlEVd5IySCTVETj6AQAkCQ4QSHiuZVsvThHc10Q51W1Qq+JdcZnpGQ1gHUJOUtgYybACafJ+4Q4WvnO5W8kOoxZFxRnM1oba4ApqElrMhqX5J8VY80hOjAkwIVk0dgpSVs1IxYuoLOhBriQLIK2D5kJ3ib05Cr4ZVwm8MhAkIoZGYJMTKTBGLWlyDLqOpjVmCDUB8Ainjhtl+ptoZe/Ia7tTkAg/gI6KdSGwxbedNupwooD8jIjwICNqnk0BUSjQcxN7UI5jxC6QkE96T1CTCjCyvW0Rla3Ba6/U6m4SsBKLMRkQIKRcjopys9wDmhb0KgWJumw0iEZaoqnnrPI60YlsSRY2qAJZBbJLLvPIv47DzDHKOfyOFCfdwuA8VUrItT18haE/q7X/R5+iXdtX80Q84Pa/lAEL3Kz2UCdedEBl2suC6U/1N4xeXcrOBUDyzwEuRnJTJ415WegXgQcQ0UBVWkXkkrGb4DwwmOfGgx2wCZ1eBruSda/cvDM4H6A2Y3wmwXCwog315jhn17Cf0Jaa4ISk/5/VnJxbpSAuVAZHSYkoy2vLOhDtxM5nO2SEBeSwS6fZviN+ksp+EJmQAAWyv+KBBcAHhUa3zESAbCTA7DZmaqf6DdUBXnjKqs8j/CwxKhTgmF/X1QRYodqMxIXEri4TTAGGC46mL2tskphZZAWUjn0+0a5RsCyDXA2KKAhYowtYrSwfuJ+eZMRRsnAc8twWwJFMZPMmhgQSys2O/nMYAnaxASzt2r2KUafJst+uNFAxATSOdziVLLzlAzyYEE+w68Cwq6Zri2SALJoAk6bHiFb7ILHpm9xtVvAGKm4TtoRdgZ1JgivzeqsD5BgtnABmQk3Y4eztsc2NLgZGozRwVsJgp2LCF5AL84m4B7Q9x5xdFiuBuy3LXDjp8V9tlZRnigW9Taz0q72CYhf7hAfBTSrUSw9FCiTk0FOFsZkOJ8QA8E6UemI0SgohRC2jVRHRgjblYfIBKyitMxPjHjb7Ujh5KhVcmoZ4UGU1yUCLSZyM0WSKowYJhmFzgO5oZpslY5lagncyYwytTLvtWOZfTHswwXa93YwO9WSMgbwanSbuc7CqGuRrzdgTqDFQjUPG3DbIJw2Ypipy4ffyLGyO4fl84Dm+RZlPk8kIDIeR1lbmmYab3AWlZ9x1vqbFi8Zc6QMDuOhJuJszZqb7/J8v/MAd1w1qbLGfD93KWpMMPz5vu7AInwD24c+eBVyXkX+zY0oMT1+jMIxbVuFeTnMMh11QAVQbbZr77htZy3GwyFmgcbCGJl5XW/hFx75Y01tb1yMC+yTx8N2g3O3rQsExwg6O0W8t8B4auF6EYN1mxHp/loDGWM8IYVpA1YRcOLGCmAnqL7cZfAyK4iCQHuD7Cc0YlGCB4DV0wS3M0gtwfVSEYkLsyhJ5JYnwd2Wqyp5+dz22lZ7jWZvsHpHuDS7x9pK9CzaiIaBQSuQZcJwLt5F4kasQQLSpqPgwNcOBrI4arGDQsI1JKTYGCxisNiPviLekj6n2IIUKaPWRuTeCsdHSbGUWaxjTrjqO5bKudiSwDHYZvCSkVsraMomIY8WCAJSmc9pcjTYo1VknQE5aRVyNjA+gZMRBGIrwXYIDr97+QCdE7ShNWLZUqqnq32H1sdaZbXKY4sqMpxZqoDroauvudgtBLCRxaE3BIvesMpmyReMyWC/a2Fsxuqkl2DaRMQ1EKwTXtUox8mM0ECOSa1dv/bcnBODwRhbUG+AswDfRSwWI8bgJECNxVARyJkQde4HALZLSKMBspC/TZsEyegTwnVTW7HjA4DuaRXCBPZ5CrKea7XIvZ3a2XNqQ0UdSnu6fyBk+eYG1f8LQDXglGukOD6TOjIv0FwYuO0eetHVgMIxCjR+hkKmtpHApX5ebisArNha2FGTsqZ0Lhi0H5G3uwOk4cF448CfKx6QkQ8Sc13b6ty/OGowHayF8zFJPUHzn6sk1AxHUNCJdayCWfeqBK2yRmqL8A+A6/WhD17A4cGfw9m/Jhb3cak9Qyse79c4OuhwzM3byOpdpBcdhwAKqSL6zEjYhBaZCaN3sMgihWSnvjjb0nqcMpjcOtjAcHtRi58rYVQREOW7GI/J+kIH1gIhhqp1QGcCoi6fL0mFaOUfljJfMFEVOyAV3IGgbHnzLMFGODeE5go1ALJywKSqYlCTRTIqSwacOkYapwy67K/MW0o1ZqK+j9F2nGrs3TqF2horXQpDItIriENGZANEU+c1haBaRWNLW9aIOSQAcCOPkWUYn5GYQDbDOEZKEsTrPQnU1hcD9RiRzQoDV+L6UcYZs0EYbP1ORIzGpvp7bY8qRSAz4a4tzf4Wk6ltyVKd5kzYphbOidSTMVmSMW3plUrW+Aw2ATl7ULBSlcwvxxKriVVtYgK40CjICX9jEMhjTKbOI8GEnEhALYXHNZuFybHSwDKnfBDX8wIDoFFeFUOSMyVD83ymxTThBMpxZX2cZgHOKDJRZ7FmLAu/fF6jcPjkhUxfuF7hxMKEBrZrBLjBPKENy6VQbEwq4EKSWjhBJdsho9lKApUaM1FW5KTJ7AwQOs4d3aNb2xxFLU+8lbQfPl33d1dbbz6P+mqk5Ve1Eb/aPOtrUfD4OrYPd/DiUgbc5i1Uy+k54lAJe6Ss9wNIfBGYnNtZ8x0X5ex9yDnhbyBVjgeXyqww6Z0qTFwTNmMLo0RZTxFhLaKf5BzgrLQmRsb+voHbWxCLnqHdZ3QMULYIK4jJZGmbFGJmJy1FSgbRQtTAdaGJpxkUDNyeQEFbdC0BZLF6N6F7GWFiBuBBbAQer10YVkmmKi8BgAYRxiVAgsEIrL+SlAtGosgxElKW6sV1AWFvYXoCRhH8jUtUHplYUEBkpnSBZIJo1AUJMHaRsFxKSy6XCksBDZnpQBvX2YRVM1Z+1HZsaqCtCu+k9ht+PtiZFrG4zChAG2OyVKuZkNRihLoE41hEdHWRJW2JFWj4ODo5BUZ25NtUq0JmqYxiNNigrVVX6yIclcCb0UeHPrgaoK3JIIjZpieusPikszBZJ6feHynvarxuwesRbjHi/nIPQ8B+9NjvWqRnHXgV4dcjVqsRl3unbeRyniQZqYGLpBKjXqp0dlQvBn9N8DcWYWWwSwR/Msj5iUYFkuWTdV1A33s5fkwwTaqXGCdBIaZkYRZRtCALrL/IkOnPnEnag6q4LxeIVmVFxYMAQLsPs3GYCFULwtb2ZSFATciKwr3dy3yvu8zozy0AB7dZw77ciFwUEThHgcg7hzwGGDuzO2IGrEFeSHfGbQLcTUDuLMLaITujQgPauYlRQB45g4/m8HN4+/G445ZiBgDkJPdFbRHOECJzrcKyrt2FWrwLal/AIMdtwHm1dbx9gIEL+LAHL+DwgMxbf3eIUNb5lCIIa/qsc6zjE3egDzZD1kyZi2ZYZKT1qHB5Wi4VOquLWpYF8+VmibfuPcMb7RWu0qpySHi3l7bRZoBfWISFR/sywF3twY2De7EHLKFbNdi/1umchhTsIPyo/cPCASO4G7Vj8QJVp0HbRQuGNSqNE4HhvgTE7Ahnn71BFzLGswbDmZtUvkd1ptXM1u4KKkVmDesvGnQvGX6b8eI7PcKJLHZig8EwPiEnC6i1CQUjszMWyLXbytwurDDTuOMKDMmNtCyNLtSjcqOMPuFm28H7hK4JiNlgDBY9e3itvFI22A0qnpukFVoceVMnFZ0sehKkE+R7ihoDRGw2NjBdlIpmFLAGJ4NMWao1XQ1ZOWhELPD9pNVrEm3AwnUqQbX8XjZDjIvdQi9rxkk7IiZbCdpEXHlg49ggJoN+9PW7p2TQuIQhiKwUaYvV+4So4r+GGEN0QhvoHXjvBPpvgBQsNrkD7QXYMtxnxJMMJEJzaSr6EDytgdlL69qSVPzFagQGsFcWcb8ArxLakwHDtkGCQSw6j3odgTQJgAR61mOHJElCOcasiUI5fnkQWSnTRWQWaTIaCXmVKgePgqkt59xmUYBhAA5VXT+uWSSaGKBE8BtS0JN8j5JkyfBMvl9cN7CXWk0ZEqCGTeBsQTZrUgvQciEBqRGXbQqyDrElmCGBFnKsF88ZdkiKYGylJTeONQhU1Z45fyvEGpTmrb3j0ckBuMPMhBpetR1UX3cEtFJBzVw7bo1r7pKt+iZJebYVuZOvBWXzytdPwUge05NySyW5zL5mz71L7LJUYFG5IKVVHIHNTYshORHPZVu5NcwMDCOoD6L6kCAFpTFiw+AtuLUIpw3Ckmqrsc4gslR3gGTE4xm0fAGyNZVMzCSBofpqQTLrIRLGBwvVvZPAx+rvlMvMqmSts9ae7QndSzHJDGuLqHMy0gqHvbT60mCrjp2JqG06SsLfSVHQkKmDLE6ljIIGwi6LAC9jgmGTzIiGXqxBnM3oR4/hugVGg5eZcO90B0OMEOzUloEkDLkR08simEtlduV5evNGr6tEMufSY1ABHYlgGxlCEuTeTHGOdECFhlvKyEmCLwA4Je96n9A48eVyJiMZcUOOySJmqVa8BXI2sGYiXu+CQ1BJqEUrXLgQpPIqsHWAQHFCvuYsc7aYDWKwEgzKPGg0yEnUJWwJTDNC/LxbW4VtaTqX5TpMyo2TmZhWL0lI2lKByh+PUdTlOHGxHCrn/+h41tcy1aDExmhQ4alIKd5eI80QkyosDQgFwopeJWWRkTJq2GmHWTFe2syl2pkfiwP1HgMO+ljx7irJr3dyD4u2l3ROiOBCkvnXQlqdpDJS5B14DLIuaLCZjyhurXHHSfXxOnX0nMMZ1xH0/Xh7pRDvYQtwvs9XigDrsfomYANykIhmkMy5unyJ/PMTPfv5VSd3QsQcBkQyJENQHXjedYKIaNJAHAOoH2Wx1hvAXHlcjgvsUoN17VMAyCLOa4YRto8At0itBS087G5EOmsx3PPYPhHR2ELMZJIbzQ6M9ophgihGxI4mlYQ8QejJ6E2bgWIIGDup3q6jF6Fcp8hC5ZJxp+2XLIoMxAAFCVzL9xjL9yOYgO3HHeKSwYZhB0I6zaBGFto0WHXhLYsSoyh6NzcZaZRh+HjG2rLBJBZMgFmHimCzNtf2WesjtoryczZhHBz8cw9/RehHg7TeY9kGUV7XfQEyO4wrsWQpLsFcUuomg/S9XCNcqjRaYKtt5eKCXIKxyTA213tyVFUMo2aT1bjTZoTBSRAEgBWLdYlLWLfDxO0yGbvgETR4OSVZjzN4fGLCqNVVjoTOR8RkkaLFCFToPhiIuppzMhXkUlp1yKJsb3qlZqhQr8DAIei/gWrLdb7ZQa4TtsIFLEnahDDV20rNTONoZaaWSWdUEji5nJcqVEwoShiwLJVu2dqkQY5wML9SsAdI3y8KmMYEbQNrMIXSQpiAZBm5zbC9gd0TFu8z3E5g89mjWqIU00hihdJzua8YVMYIhfdVwF/Q9SclQfx1HrmR4JVbqk7KbiO0mOFMwEtILDNz58DqCXYAlrDCoStJM9WbpNwrh4n83JRyzl29hbt/lSL88Yzqrr+X/88GaBUUcpe8VPn5mzwv3WYHuWQdElwOhXmPB5+VUX6EoEG94VNF1BycfJVcIZIAySkJjBVAcUvllEAhAAzYqJXIvYCUDfapwdKMMN95g8uLU6z/53vgvaCXKCTYIArzubXw72yw+7ZT7B8YhLUu8NCefCwcFxEtXT1l+JcR3QXh+mMOYS1tuLhSxYQugwaD3DLSQhyE3V4uts2bMy07p35KjqcheKSqQGEHeb/2mrF/YDGeELYf0YWdUcnSnAlxtHWhIUUm2msDGyRA2iAtx/YqYzxxSEtRDnF7qvB5Z7NqARJOV31FFaZMWC4H5Gzw4mqF9rcWWL7DaK8TxqcGz09PwQ9vYGxCXOpC1RP8NmM8sWDHMMuIHBXQ4UVYt1R3BfhgGoF0F0UNMMEukux3dKBktNXPaLqAnAzi4OAXoba4wiCGjaYVUvODsy3WzYiboUVj5FpKbDAkufYWTcBrqxs8269wue9giXG965BS4RwxjE1gFlDHogngNTAMHs4lsBWeW/XislnQicrj4gRUcntBkhLDv3STZFgmmRGq6K5w3+Q1/SOuRqMmKM2gY3Cb5Fiqmj2djVKJj1Z4gUaCeqYslZ8GmooczAA14nmG0VQOIQiCIqz3PIQ/WEbeBNBgRIZtnGDwdpDrLKs2pSRmDNaA7DaE5VPG8lmu1VWakc/YADxOwUsSUeGB8aLVjsmIfHklnZJOLGkIAFkBcmVvEdce/X0Hv8nCLxvk/drrLAnnAqJW34/IwzjNvFLWNUbWFnK+og4LHH4CaMh6ZRovM/1yqGZE5eJnqBfR3VXXXfD4+VYwAccCu8cjnFtQ+m9C5evGWThEs97D7XbfV3ktACn5qyDl4Vb6uHXYeeCpQ5oBWRAZybp0wk/q28Mxwu9YBHittmZAMJTRUcAnH77A5x6cgE+WIh/DDBoC7F7UOcyQwJstSo+8KiCUr1taNiQ35XBCyNbCDawiptIam5BMmPTqSIJUagtoQZ+nSTZbQd7Z3iCeyMuz0ziv1dn+gQA04kJ5ZbNWnyyM2sYpthSBYPXzZx0zpsYgWzlGReoKmcWCY8HgpcKQEyFBWmopG/mMTEjJCJl557DYAM2G0V5ELJ4zrj/Z4tKscXJvhxuzQNHKs0GJqFl4UqhggAwRT5FMvqAFDbHYfGi71ijKLUUrz9NZUkoGiFYOowr0MhQpOFrYRUTbigtzgbxbk6WVrIhBZoLR4LmPHmN0SMnoHEXmNZwNjAJDTBPleLBatuh7ApCgDAFw+Cai3zXCPRs0odBroJCT2QiEXIA/qP+AGSpTT3Jc5tpmS+q/Bc/yOS2DvXxWwapQBVcU6ae5uga3eUIOBq0atTsgxDpNHNMEd6//GOKsvS/qLgL+oTS1+ChLccQGCCdcVWP8tRpSahNEELL6At2K7QobUZ03Qfy82BnhtMUE7vu6IBfUMacs1z8RUucEVWhk/9VU9qTBuBa/Pb9hmN0oxpbjqB2l26jBA/CE0eoml1bM9LmPRcjn+5iedNyVmlVgx5VS2fjwfW6JQ9TnHbUbP+DABXzIg5ccoHxYLn+V+detXm95TinHuZhKHmUkJXBBBXjnFwkRYMU9GYCw+F2xMchobhL6+9IyoF7UHwDAU8R3nD7Fb9x/E/HeEr4fgSzSMK5PoJBh9wG81WEW6U04YqYCgXoTZwDhVIJJs+FKrhS3WaAMo4lRFw62jNRhmr2Vzo0O5s0oGnDZi9Mr+4zsy3yBlCcjbZasivKgmVpFgYy7CW4vfBk9pFFU9wGauDUBsIkQVgxeJNiFtmEUAl0sTgQCrq2wnYO5dnBbccR12wj37BrrL72Gq67B4vEVrqsZpB6Oyj+ZHgNBnI8jiRbekkG6AhonKL8iHhtGJ+23rK1Dw9KS0wWZrIAraptMW4xdE+C1LRmStDN3wU/Hiqa51iY0GFQLsFRQRIqsZFm7uiaoSC9VBQ79gjJrYgM4sWvJUaoZsxMRZW4EpEKDkU6SAfIigYKDLVJgYUo2yhxUXpuRjQEcYB4M03vyFNwJQCpADA3mKMejrHlKTC5dJhE0NgLWmF+vR8UAnF6wmUADwd8YMX5Vd+RCtyhJEZFWYA3EEYAAtzdwe6mkqilnQjVsZSIYFncFQBIsq1Kb2al4b5QRQV0LyloRItgYEIDcWiFAl8oySQAMa4ewIqSGsHo3gfYjEIQnxlWGLtUEW0Aa40HFRFTGCEcJuLUgpNvq86/ABNwS5L2D+Kzf/K4Xf3U4/13yUMB03/0+tw958Corz1HPdqbCjGPb67n/VjkhmRUpKNDmPMjEdvLmSnpxzAanMc6gvTOUD5kK2gCA7t0d4nINMzLaFxb74LGNLT7bv47vXn4J//c3vh2X33YPj770XCqszon1AkMQSeuV8sFQyc6pkaokd6yWEVQh3tQAcUVVYLVmqJDDVER162Z5qrwUmOE2Ft27k+6dvzaiObjISPcjUpQ2ottYZDcFhSILlZdZWkQ+wzqpGNICSAaIQeV1sny4zUdIFk29EouganptlDmXLsrtItR5V1nMuybg8rpF857H8iuE07cDKGYhFBPh9O2I7Dyev3ECWkXEJiMtLV58h0M4Y6RzOYekZpocNesnOS7Gip6icwnjYGrgEoKtLNIcC68qo+kCxl0DGIZ10lKU64LR3Ze2cD96RDuRkVM2uLpZwPmEJ2c3uNwtEEl0GkO0QnYmkbdqmgjvkj5OcC5h1Y5oXcR2bDDsXQU+kGHYVgjVaWexe96i4CVyl2FGkiBtZOZVzkcOUrkU6TF/o5eOE+J6mYs1z1wVlF0uB/S9F9HkTNN5CmbqEmThkZUEIJVjrdWmiGtLkDMv2srFSw1U55DB6wgECWxFPcP0Bs2VzF+LmrzrFTRkRQKNSR4Pp3IPmL0gRsvzx1NCe6lVmkE1K2UjeoPinKwyaiPLrM4ZcUgGRB5qdkvR6QnqXMdaZC9CAOOa0F4Kv8uMGf09ARI1N4zlF65Bm52s51WVXroQB8n0fC0bx2nWNh9xFNHgorF4pLBRUdRl3JG5KgRVS5RbmoYS4GCbiSxNJegVPcdXB8fbCJ3/f595FU7BXVkBZ3BU5YsDaRS5oY5tBQop99ZbqOL8K8mCZEDOHJ64LCefU4K9uIEdVjAJAgtnQgbhMixhF4xvuXeJz377PTz6Tw7sLPJJh3Dq4DdRMjTn4LcZvtiGlK9YKq5WWiDWouooskFF0okywpQx17lCWaT1u0NvZGKtplpIOynrQD4DbmPEXkP3E9cKSSZIRu21reMzbJeUnCt8ENtkZMsIDCUDG5BCHoWrJvspcxPjcp0jWSczp5wnId4QLPp9g+6LDVbvMtbvBHTvbpAXXhyeVx2aywGr9wyu329hnvSwXURaGuzWpR3M8F1EilaUzYt4rra3SiUwJ/2mKIAHUp8qRmnVGTBluC4o14oBn1Bko2IohFVG4wQIEjLhZisaWcYwQrLoGlHfSOpPVnlm2VQOW+EKOiMIxeu+QypBI1Mlczuf0BeUJEliYhgQkWSCASPDVHX56g/nAE5S5WcLgYtbwPWEHCSpqudqkbDbtfV4UrE9ASYelt4uRdOwakEmAW0g2sleRq+vDKrJkxkFNRiLHTig7tCiAuJv1FyTJ8PI5IXiUbznhM/FtYMBbZNmJ/uKXanSxIfPjhmmVyCKLrR+o6cwCqydtnvwbi9tvq6tsyB+cQE6WQuMnghxaWoFaPsEJkI48XLfBsDvMkiBGnBuqryMeAMKJP4V4LP5ugbMaDzTbOs2T2vOfb3dbgQmQ9/pNQBnI9Xc7DW12qstwTsKibskoj6A7cMdvHSr8M+CCnyVe/IxLHR2UA9K7rlyM5FcSMcInVkpTNYclefFxZTB271UUlFtHZJBYsI2NbhJHR51G/y3jwzgxqNINmQvUFpWUU+/SfBLg3CinynrBVEg9a6YjhPYy7xIWotTYIFmzJgN3Q+qMmgAJwa86LwZK/OQ3GiFFwEzkFzvRXFjRvJlQ3WfJXDJ8ZDF0zhGXkaQYeRgEUfShVEBAwDQJfjCqZrB4lnnXKR6eLH3wLXD6h3G6mlC934vRoGtA4iQGwuzG9FeeDQXLcaHBNcmdG1Aexax7Rv0+0bs65P0jCpfS6tQue8IKQlasMybmOsaOp1ySBDzTTxILov32DhoFabzm7nLc9OIfUliErdnyJoSo6mvL8TjYsjpTBb1kGzQB9l3VR8hrkGzzo9q9S3iymUuaVQYVojHXAniUmEVNwPZr90TDKgiDNmwXHuDhW1EuaOQqcstcpwQsqpt1KDGR5+PlaZhMM2toEChvXLvSGeX6q7st1ObPOt3yHoNC6CJK3/wgKumHF/KQIqo6FyAYccSpERVnrLMqnJrQWOGu+6FDlPWl/OzulDTxoDP1mBjYLb7OtcSuyCB6KdOv4tWnMr9wETJyTLLmqOaCwiirHN5usdeiZ4+/hk4SMRrYn9cCR2MYrSFOCcmH7/XHHl4eMLxB7V9+IPXMUt8Zgw5neBiK0C33JXLPqiQDTNLMGIW4EDfi0ZZsT+p+50uMrEwn2Zooi6t0SyMsGMW64UeeLlvcT0usPYDfunqWxGzxVsfeR/p7BzuS89gXlygOf042BDSuoEZV2ifbsC0xs23tDKHGPSz7yZSb25FSUOkdHhaDAo3SbUOWf9eTC3rcw3XxYQTEM+jIgxFzDStRJSXRiEqE2Roz2Uqb2UhA8t7ptGCnAjW5qRZNqBoPsB1Efajw8FCP+4aYNZSMrpwFp0+YxjLdsT26hTNVxqc/ybj9PM7mH0E5Yzr7zyX9wiM5TsRFDPcLmD5XoO47rC7b3H6cAtvRemCDGMcLchkWD/NZwoq0NgEzoIcXJ/t4fRcX+eFVA7aWivE46gweOcTFu2IcezEQZkksJFGiTFahGBhDOP+2RZLL8K6fXToVRKKAcTg4HyEcwmtS+iDQ79vMW4bnNzfAsi42ncYx+k2NqryYW3GOFpB7EVJaqrNSSDEswyKAnJArby48qCyB8JJVtsOCRR+KxVY7AC/kUU0MIHXUZMVRhpNJVSTEcpAOb+ZSTh/owF8ru1ZuCzKGQzwYMGLXGdjdmeEO9ZKwKouCIp49RtGe5Xhd1nAP16AFakV3mBqJdBmL8GDHZBtnniUWYJW+5LgtiLDVio3EwjN2zegvcz0eLWA6S3M5Qbx7a/Afvu36kE3ePY95/A7hklFIQdYvIxY/dcbbD4qn/n8cwmptdWxuYCdYmewWjVw++FW0OHAkyVK5tpJqn/PMh4h75D7oa5Pt4JPvUB0XwVZPEv0JYiFuo7V7RaKcF4A5Duew/I+BY14jGr8JtoQ2gK00wEhmoIGUINabRHODzRPlZo+SZ8yL4l5UomH7KIOZIsoZnl9QSYSzRTnDfK+R7EyYSKMly2+tDzDt56/wJkPuN/scL/Z4dcfvg57cwK6uIa7HABnkJ1BeLhE87vP0FpCc9Wo2jUmjy2dd/HAAldu8wFCq8rjEGQBmw/L538vbZv5deUY2aYa+CiSCP+2R1kegKI1xxooAYVHl6y67NdDRFh1KxVNzjqHIAZZRtMVoIb4QPkmwhjGza6De69B94zQXUbY60FmZssG2arJpCFcf3KFxfMGJmacfDkCcOgvGmyuHbav9cjRgIOBWY2wlkEuwtji2QWd1QEZGa7RysMwnI3oW4+iGRhHV2c7RqHgORN2fYukrUKyXGd/gHwfp0EmZZGvAnT0arJUwExo2iB6hMTY7EWb0LmEYDOGwSMYLsV6bVUSaWDWahWKxqVA1fIlnOUqWFttfDJgBiO+bjQ97nZCkbATJmO6TrQF7FcjchKTS47SUuVMyL0FtalWtGBBZjIA9KbKNZUuFpckqLyJEaoEVBIqDwZ2a+FGoLmSwOV3QrVgS+pFRxNX0WtATtIipUygAYIcVHQsk7YUO7k/swcWLxhxYZAdYdF60M1OtEpTBjkL3gs8ka63yPdPEM8XaLaCYAUDficeYZSA9Pp9xIV4odlB5KVsEE6mIIL1+c9vgL2gFskXR3ACmeKEbEVbtQjuAnV2VeZft8YaRYShcMVKsDkGowGHa0Jp/92FHpy3Bl+lvjF//l2B65s8L8kwDkjKmErigwHiXQjEI1XK+fNv6X3NgiBZTH1mzH4uF87xSUlq+61tCntjcXWzRH96jRM3wFPC2g8IKwNuvfA0dgO4dTDwGE9ED42GiOaGEaO8V25JZ1fyjwPpzarCvEr6pESVw1NbiAcHcfbzbD5RqzEFcTCbOiertuoZgvqa7ZfK30svStXl6/uWVhFQwRdybKlygAiFjIxqOVIs5Idtg+WFKHv46whKCWwEzWmSto8Y2D8woOzEaDBkNNesUHyDzdqjEGM5G7BJdb5WYeZa6RmtHPt9AywEHFFamURA0tYcqVlm9a4qsHD9nsZN12BRCpHnGcBMgc2V7826P2jFEkXo1hius6QM1GquCO32N51A9y0rnqkcd6rtUJQu+EG7DpWqUOaPZqSqklHQe8U/S/zXJDhYKyopPKvyOVPlxVUUa5HSMixVve6fjVZ8BkhdBrelMpLn1euGps/oeobfT+dbKi5U2a9cfOKUYFz2U+4XgCYyvCaXdaSm3zV7Qlw3aK4cKEbx2QIA5VghRk0AivK8BpVM8JsEO2YMD7oK189OBATK95DvwnB9FnRilI5NMbEswC+aVTVfCw1IjvWhkkZFE+aECrQ4Fua9YxY1H8ncOasqweh4Xb1FcP5g5lzz7UMdvA62u07wQebAE4QdqK2+OuuqhLvbIA+ZXyn5OGrr8Og5ZNzh8HMm3mtChg2S3XXPDPa2w+WDBTobsNIAFpYGaeFhjAH1g4A+iJBdh3y2AgAsn0XEhcG4NzDBSMtQB+piskgADOJJAqmKe+Hy1GBUAltRNJgJndaFQgmjZKWdQy0jWSsiBoGqPxIAcRI2jNQXLSGGabMuAAxYwLYJqbdAFIFW0uBW2olkRLm9zHWKxNF8y1lsNez7DU7ezli/M8A/vQIaD7YiatxcJ9ghSWbtLXaPLExktFdyLBYvMtZfzti+afU4QD4DBLJeFc9ZgunyZEDOhLG3wKXH9tzgpBsQRld5VtYlqdwUdJEVtk6FR6Ww7xRNPZ7QoM0swAqvFdQYbUUhFtPJzFT3ySxwe6tBzFohcO/3jYxMbMbycw1yC4R1Rr4fp2TEyoyKtIo2PU3UvvIcltZaQX76jQQyVrqFiXINh7OMdB5r9ZWKdJhW8JVMbFkQjVWtItVjbCLBDtKaYwM0V7KP1FnsXwe4U+7XzoKiqcHT7UQP04yCKjRBpb4WUnmBiwu4AJmyE11Ro3JWZa5l9ziUISuGqF4oAqwVfP+4hdusBKBb9EsbD6xXggocA9wmoL/vUTKvbAndU+FnXv2JM/Hgi8B4YqTKgwT0bAG/EwNK7hpgtwOPYVLpyaqRqD5eRb2jrmEqIl4rMB17YA6qKHJVZECewGOubcVqh3JXK08rrDtnXHS8Zs6D3B1V1TGZ+QPaPtTBayIpz/u7h2VxhcuTObDRJudvs80hJbYQDQ2gwruCRLQHvefy/uU1JXBV4cxSFcYI93yDRWMwrlo0V4zxnPCtZ8+xsiMWVnrM/UMCf8EIKdkQ8OQh8sLD30Swl/abvxzgNgbtS4PVuwb7Rx5hRaqOjrqYmL3YLLBXHk+j7byCOitMZADV0p4hC7rLcG2q8x/O4gJtmwyzCAg37WHgAyqPiZUTxJZBXhyFqRX9PmMTimlj1Sa0WYAMxHAui9ux7tu3AnzImZC2DokczI3F2eeAky/u4S73oJiQly2gcjtxaTCeiNElWwEjmCiL8XhKcDvCaptw9lmD4RwY7guUv1SJRfgWkLZh6wNyNkitwdiIv8z1voNvIromwNmMm10H76MALZgQo8DonUsYjZPK1KidipUZqXPq8pyh2oVJ5KCSwbOLExiF5JdqswSvcXAgw2jbiFU7VrShswm7vsX2agF3opUVQZKRkrww1MJE2oDstWLMmCw5tAIp1ceceA7o/GjJSEuR0OJREpJ6TWS5bar+Y6k2CwncAHkwwGCqzJIZoahBRbTugewtwtogrfXec4LqdDsDt9V24Z4rH2tciz6g8A1n17aRa7u0QI3qHIr9jnzO+l0hj9kRGFWCDQQMxqA7aeGyAjfUx4u6DsOnnuD64y22rwv/q3yf1XsJ8V6H5CXBdHsIB3GrnDGWam3/WIJaewlQlODEs8rrgKSsbhVk7aSZOM7WPIXXw1s10dU+r9GWIbHYv5Sku9B7qkDDHZVRScArZUgXjMp9nVCLB2RqwtE6PJt91X3TwbX1+9k+1MHra9kqsqZkG8fDzLueP3/gjjK97I9Q5m3TjGxe7ZUWIm12cJctKLd6IRMuhiXO1nuc2B6tCdg/YoSVg4tRgmdMKhWVxJI8McwYkRdeyb6M7AVuWzLGqj6gqEJ2LF5amnEzIATQI3SXRDx5DZXZV0nLaxsIcgzLXEID0HRQWK4mkp+NPsco4KI8hzNVhXVSOHfZDBUVBwlsKRlBAhJAvUFzZbB8FmFGrYK7Btw4tU/JYiion91vVEVDEWtsRUkkNwbLZxmpNegfAb6JtaqRAC/nTxTYZSbXtgHp1FQ7kxJUUgFh6GZrO5GraWZWLhNpezFngxin+zgkC4zQag0V7p6TgbWlRUkCtSettrRFGLPBPjhsdh3iaMGjQVxN6EGocgaAqphSBHXli0zoQlIgRBHWLZeGVO8sfCkv4AdYUX4XzSRUQjEYojKjLyajSvDQa7JcJwQhIGdZvJsrTYIskEkMME0UqT/SthyI6+MmQFpt+hpWVGQVdzao1jr19OjPRTXEjFPrjrK2DBMm4WgNctI+NGBvBc06BmnneYfUqmTbPRa1jh4wkbF8pwcMgRfiZGD3XL34isQUW/2sgKjJ90MNALdGDwczrGl9KQk4Z1XaV4Wf+tyjrYw9jn0Kpx2+gqMlT5ye8yrVjq/2+t9Lcur3sX3og9ctleRjra4Zr2Eu88Rjmi6Gg7I5TxdPhZGWQDdlGkVZg5mELKjvXT12ZplIvryC9Q4mncAODH9j8cXLc3zL6iXWtscjdwP62A79+QILScdBIcLsxunCTQnUj0BzD+xF9aI/N3X+kFrt8avgaEH/iRiqLmZEVTGhogzLV1PEF2mwKYttqYRysKLQYLjCoquCBMu8wjRp4ma6VKHlOZq6ipT9MUsA6JqAxCSafD5NVZnJCMGKiWGTYF84NJfA4qkMy3MnkPjUWtGEGxL8dURuZNDudhllTpIblT+ykqUv3wvYPWzBrZCFmakqnwwaaAufzJqMk04qnZRFniqoTUlWn62cxaW29VE9tUQlY9mN+l1ln9tdizxasCU4PVbD4BCMrS3AdhnQjx7j4AU1qBXdAI+mEQV6a8QZeQge+12DfONlHmkYfBqqZqAZTCUbx3USIrtWVBM8HuAmw+wNbCbh92W5LogBkyToh9MsgB9FB2JQrcI2g/d2yqI1MFWaRlAgjsuajDPYZVC0IA1Ei5cJ49ogLIXMPletn5SaaKJrRMBtEtLCIvkSnIXXNSclz9GTJREr7+m3UlUaDWYCqJL3ZNIgmVBnXzAG1I8CjGga0TUkDZotg53A+dtrhvuNz4M/+VHEhRXh7BGgJEatVJRM9HUmMewuIm+20gZUwYSDTSsr46iioAEIB0y7R2WcUdeheZfooDNF03o303SdXjohtA86TDUols80b91M71lHLPO/6d8/SKQh8GEPXrPyd859OOixFv+arJwMLZ9vbTNVjqordjw7m5OdVVG6Qu9LZqFs9Yk0mOWi7Ac0m4zYGrgdY/O/nuM316/JaxbAX/jUb+H/+dafwL1v/zjopkfuPLhxyI1FbizczQB65z3gtXOkhUM4saJbWDL4E1YbEglapTrKYULQAZhmXFYkjyajPxngMgjIYg4oVuyM0EsrrGj9AbIgt23AftNK+ygR4JMEN8NIihDsFj0yE4bRIScD06YKZghJVCtK1RNGB+sSnMu4frmC8eJB5XxCSq3weS524EVTz4cxpBycDP9iK5WpNXDPb5DOV4inLfqlx+kXo7QWF4Tnf6zF/pGcx4t3T4EmwzYZi+UAp6jAECw6L7qB+9GjcRI4Vk3C1b5DHy1iNGjbWAMKACzbsfpszQEc/b6pGoWrkx7eJhgChijvY3Xet+lbMBOsE3PGqLqFi6UEwl3fYNi0U1WcplYtANjnovDBZrL5YMtIC0XYaRuR9gZWF+64kpNaLVAgoIj2AlWBAqcB7SJUonYajQJeaPosBKDNKnpL4L2tgAwA4Otm+pyqnwiWVl+pqJigLs2A6SeXYYrSmnM7hhukgg5Lg9gJ3Lx/AHX9nqouSVwY7UsDr3My2xcSMtfK0iT5ObXSgk+tSD9lQJ3GM8xuRH7/Ocy9M/C9EwxP1tg/FC+u9oXBeJbhNwaUWALcV56hG88RTs4RF4TxhDCcE85/KyF7QvAC9282CeZyOxnYcsYxv4sWC11zEngGhy9+Xpxv81s5JVSBcp2hlSqtrnfH3aecZqDC2ezKWNSsdI4YnAfFnMBfTUXjAw5cwIc9eB2V0VPGcNdTiwSNDiHvEKkkQxoQcWdpfKyNWH839hByr/8vclFl9tW9P2D7kQ7EIiD69PoEJ77H2g6477cY7ifsPrrCya9tpC1mLdLCyc09OvjTE+SQQMxIrZmyZ+XoTPps2iMxBJgJJMCZJFsucbYEHUDai2Urs6xMyEQKsJB9M0NklFj4TAVVZnYGuTVy07O+NnmE0SHtbUUb2lVphXFtw+UsCyIRxPOqVH5a1RgTMawY45lBOl/C7EZZJIhgN+qInRnsnSIwM9jKQmL3Ed0LwO6jGG2+7hFW+jU3gqBMq4yECFopsZdFZHdQKxUGEJMBka3yRiUwFS8uIkbUqouI0foooIuoNiTaFoQRtfoIdXxuR6n8ksUQLYbey9ztKMFKKgklMktJjBiLSspstpQVqcdGvkNa8ISoK5e8IlCZlfy7I22/yWVjd5O4bVyKIwEg52YCtUxBi2prkKdkmwHTS3WVG+EKTi28qTUJSPAqn82OqO7alCQhK350NUgWIr9WMGFN8j0tJlBKQnXiLnqHtpdgVESZqzAwQboxhqoJK7IEuPYywW0CaD8gDwN4GABei4XPiRq1anD1GwENwRhw34PGIPNoW9Q1IO1+J+ASvwWaywhcXAlAyxCQBRpvrJfzAQuEUCuuQzj8IS3oYDZV1jEyU2u7wuJnVdBxOw+YHpsHrPnjAA4g8wevOep8HTz/6LnfYCz7UAcvySwK6a6cyJn0iWYXVXOQSuaQp2AFgBNuXxRHJ7dmNndwH8j5+nstscsw00jLATHCv3sJ89prAMsQ9+a6w7vdKR60O3xq+T7MgxE3H13g5L8EEDOME1004aJY8Oka1AdQ7JAazKzZy79y4UKDEoNUt5AzpKLSyoITCVmUUZGFRdfPWEECisSZgA3qHCRR9U9KnanvZ0ZVTgBkrgaAgyhJ+EtbjTCTE3dlYwHvivcRCT/I5yq6W7hCNbFbRwznHvsnHZZflkEWGwNzuQeYwc6C1ypTlBi8bMFOzDzd5QAKCXzeor8vCx0l0WwEpC3EnaDvikpEzsLHKijCyATMwF7OZGQSLy1A4OwxGRHpJcD7KMaP0SD0rnLACMA4CFoxe8JpN+C6bzFGh3F0CL2rAAehIso5Tb0DegMYwJ0Nknjo4ksqUssE8V/Tc5VWuRLHaa+t8zLL8SzHlgTIkjpG1mvK9bLQisyYADQ4GaQ4JTXF46sIOBdlC2iLmLIgGosjtqiqcw1c1V6Ftd2t6iwmMKgrgZHqNV0V4lk+cwFn5EYCbPY8q9K07TdKgPBKPvY7mYvWlmRinYXqdcvy/W0WXy+/Y7QvB5hNDwyjVC77XoBCjUFYyfvL5xaNwuZiADVeUIMAwmpS6PcbrpD53AD+huEve+TLKxFCUJFdFERzGU0UbldOVadQLro0rTOcAfIy04phChacDmLEnWMWviMIfS3bK8V7f4/tA5KI+lAHL1Ztl+NyeY4crM9T5jg54U3xMACmiPOmgxNa9QxjnAIfACAdBLk5SVBKc/mZfHOANoS14BCR33kK811P6pCaXjZ40a7w3vIE//35/4rv++Tv4D8P34Y3/m9OfIJiQkckaEMDaZf99tvwhkAfbQ+OBUUCHMAmi617nAJR/WbKyeLegvaivJCXeXIMJtTKgaMujkbAF5wIOdi6gMKKEoZfBGARkE5stb8AZTTLURQzNk7eX9ch2ljklpD1PUW30IAHA1birplVZJwNht7DdAnjY8J7f9qh+bYzyaJ7xsmXlnDbCBMSstdg72RBGs4ssiPYgTGupW3TP8pgC/gbscMY7zHyacTqfF9bd9YwmkWPy+1Cg6lUUkRcvcRKOy8zYTs0CMFJq7HTRSuIDiMRYFxG3joBNii/KXaMwTE2lwt53Gcs1gPGoYPZG5iRkF7LUmFpZbP8koMJwPZbCGiEfGu3BnFNEyDCMGg0kn91WfYdVEmDparJbYbdm+okEFcscyA9JmyA8RToX0vgTu+t3kieHQhmZ7F4amrVQlk94zpCogxeZLBNSBngWesPSpKnkVSHE7ADq7uABLHiuRUXXAWEKUgFxUrOTx4gJvQPCWEl8k+kLt3FKNX1Um01N1ydx8VHS5OBtlRnDBcY/kZJyIlBQ5AKPkTg/RdCx0gJZrmUoNSJMWypEtkKYrK5TrDbEXj9MSgzwuMTjKd0EDzZyOfPHjj5cgbtBin0hqEm1GaxQBExPQBvGBVFKJOSWSATpQ0zgcScq/P6uXRUXSvvEN69G3FIR+toniqyg9fOtiPpvT8o6PyHOnjduc2qngotnf2NkyjESx/3qIwuT9NeMvlm9toZolB/L71mkDkAaACQNhZrUAyCIKSmQXMxIvsW+3OD7pnBrutweb7A03iGb1+9h82nWrz3PZ/E2a+9AN5/AeMswhvnYG9gdxH29ARMhPYqYfdYFpBMwn/JLSvikMVbiVTySDNYsjIDKyg0bvS5824ok8wz9PlFCZx15sWeQK3Moshk5DSJ3OYoLYrSgnRtRHIZ+Qx1tlah8jNwSAWoJULMFgjSEiOXq/QSGYC6hPEBYTwHzCgOuGHpYZJUvqX1xASkBTCeCdfHRKqBGExi1NgScAKEeyIibEwWxfcoKu5dK1D4Yuq4Hzycy2hcxLIRCP0QHK53HYbBCxBjNNhutQonxqhVERVdSUhrNxMm4vjezioRoHluYQdZ3KNyxAD57HEpLtVmMCJxBKk4SuCqMlCqvJIaaeeaSNWmBpB5Vvbi21WqLjbSHswe4s/WZvAiiXq7VuF07eC2hOaSamVW2o12Ly1IsEFc6L2QZzqFkcRwkqcATklAEW6fka30vGM3wdTL9zN5qnpTK0lZUbmPS66zPDOKX5zbS+Uo6vgStADhXxnlNFYgyKzIY2+lAu8cKGWY0cFulyKwG6Xqso8fInYebs9YvyO8y7Ay2D2WNqesPwZ55ZFao6hXoKh5DKcWcSnfcfHeCBqDAED6YVpLMAUtIkI+XlvKvVoDkXSSirLPgZdXXb64Pq8GoPLa4+2oojrQQizbXRXaLT4Y3f3cb8pDyXYbVDGrjhIOKip9gbQJZ9JOxEds85yE1+Vp4m+9gtl+DD+tsPw0EQXLvk1n4C57NK3F/n6D5goYTy02Q4OLuMJDd4M/de9t/KvveAvLd9fwLy6AQRFrRrhL6FogZTQXI1zvECwBVqG/ReRTYcoABHnGNOnHKUS5KmVoOywbM+nLJYWzqyAsqy0HDANeABRFPikqgs2qdh4IVT3cWOFRNT5iDA5JW0pFpb22OQnS3iIIqTeSzGUaWfCMtsXIMGgt1igxWISN8ASEKqCiqwpgSF0GzgKMz6JIr5p6dq+twlatYNYRrrT+MlVJp9Ew1otBgaMC2Y8AiCzGlDEEafNxFqNJRAINUs3OgxG3BFpEqXqTZM3s9FjqrARGzlMYHZy6VcNhIo3rlhYzTUptfdVkpcygAJ35zIJEBvISgNqMoJg6YrpmWD3Z2AJ5mYBGZ6N72Q9YACDNNaG95ANQRGqlPZjV2bu0Dk1QrhiAucLKQQuQtfpaCDS+8MQE1q7qMEb4UdlKYK2Cuws+DN4swcqOMq+qgau8tYHcQ1wSnen4pk6q9lz8vxLD9hnmupPqw0QJMqcrsLfwO8binS3S0mM8axCWDnbMlRuaOofcGjgN8gIqKjNEeWt33Uti6xzIjF+97TaXsptv8wClY42v9rw7fbuA37NdeGv9+2qtv68WnMjgtrTH72/7cAcvVkwvywUqgcMdEuYOQBfTz8Lnmmc0M9RgUVAeZxcU5wNRTHKtGFAqTJWaqUojBVsU6Z76cccAevd9NPYJ8IkG3cuM8dRgs+3wPKyxSw0CW/yRP/87+PzNt+JJ+ij828/g37kAtw3ySSef8flLmC98CeuHfwzb1ywGK5BduyOALdKJCMrKh4Hc1QX2ngnsRAvOX4rrL4ws/vksyvxkJu6bk1VvKos8Wpg2iQHkKBVDWZQKHJyTQSwcIH1stK6qTvhW/cAgAc/7CCAAa5kx7a87mK2VzHgj3KZ0lmpgpCYhwYD3Fs2FReoY6V7E8t4eu8vFdG0QNMuWQOxXAakzSN7BXlukVYY9Cbh3ukVIYvi4aIOKAIvJZXsSwRAPLufle297j81uDbsVGHo8yaJIAtRFvgjeZsfIZMTdehERd06sYKJKJllxirZXDugtYt8hfCQK5yoQqLfgVYRpI/i6QTpLSIaBIIaShcOVIZWciO8Kuo+toNmqeaTjybeLpFICS8swOyCts7QIy5wpGlG3YGjbEVg8o2rcKFwrmR+Na8jsp1E34ytpOfsbwvAoq0I91yqSbWlVFqULFrNLo228HdVqL+kpZQuM5+KYUBVl9KOKp522C/cSeExEdcxmOwFCUqPJjdeAa5Uf9pqtszejLhBuYJhwCnczSPXVPULSuWr3fASFBIoWdsg4/9yI9p1r4PIaRIT05hnGtRXQiZPj7rcZ1x+3winLAPVB5lkV1afHJxRktLgvm7adIPLFPaNMLHQ+ZhpfSc1ciISlijue1R+vjcdb1X6dVWczhOGBZNTx38vry3uU7UBE4o5W4u9j+1AHL3IeRL7CQqc24HRgDtnhs9fOBpdk8mGpfXSiJZOZedyQAWYCmigq8uViAR8x2IvFQQbve5ibPdqrUwynBnYEwheW+N03HuLjqxd4rbnG/+nxf8X/9X//EVBa4SPvXYGvroENwaRT8M0G5D3Mt3wEi3e2YLtCdhb9Q5HbIQbSKTAXw6VgRImeHdyeJmt0XdwAUdUeBi9DflUJL6CBpEThwuPKiWRxK7JSpO0jDVqm6B2itD5QL1ZmOkAZDspnKrp9fjkieRky5yDKIuR4CryqlG6G0lciYDTod03V0gMg1Y7eI5yMwu4TzIqR2iQow9Hg+maJooi+6kbcO9kjZcJ+aHDTtxiDw7BtKk3AuowIIC2zpD5O1EQ4Ciy9VBZ2IKCVKouDAZ4t4LXSYAPxwiIA0WjLisEn2huLToKfZ/DGgbcO/poQzqC6f+XESiUmgrO68DkWgd1Rzq9U2ATspCVYWnLyGTJ4mYBBzi9Gg+alRWrl8wCo5Ga3I9hq8ijVUnOTYfcJ2XsEJ9eVHQDeajVZVF5m1WFBApYZXG4I2ycebhDifVgp0jFLu3c0pWJSKoha5xQYPZN0PtzWwAaA4qwDASAuzNQ2VJ4VWyC2BDdwRSwKwFPbqqMEvjIfQ86KBjSglMHeIi0szKpB/2SB3UOLs88PoF2PvNmCzu8hrKy6mgswR+45FnNNAH4L8QOLUYAZzoHTMUIvC/qwrCclgZ7ZNYHVgPL4tfO1iyY1oVp1zRP1r0Xxfd5GTHdUTl9LG1E+0DdnXnduMxThXe1CAF+1NJ+kUr6GbU4mnLPOb2Ub82EnS5AbRrQXEf15A4pAc0m47BcYFg6dCViZAU8eX+HZmy3SgxOY7Q7Y9+K0mlnAIcbAXmzhzzq4M13ks/T9qTcHoEszUDWWtANVAipp0UMsMwK3J7A1SGtgcrkFDLJWtpiqyYypqjST4oIYEh4fWAYVwdsZt0vmcdB5h2zWclWWGK3M0YxlZJrEXpmkB19I2WCF/ZcqkwDjuEpSxWRr5WddApksrr/BKCEbsGCFw7OCNISbFqMFRwJnKyhJx0CbUIwX66nW2Z+JADKQLVf7EbIEp4s1SJFxURbLUglVwMVgqzs2RTknxfpj81GLcCbK/nR0eVOWio/ztHibqBUR8QGlAiRtU25EP5D1PFCSIAViJEzK6xJIUNt8BTHHFgJ+KlI/GqMquMJP5/9AsYVRmyBsZXblBmnxmUAwXg6UVH3QVUp3QNP3LYkXG66frfxNHke1HwG02tIWJDtJwspxkdfJ/m3g2nqkzPJZU9YWn6lSZGw67O9bDOcE+lxpGRrwalEDYr0+NIlInc7j9gwOQQR5j4OBJstVEHwuYwfUtafOxZTiU9e+8sZlLu9pQtUfB6hbFdms6jqGvR9pxR4CN75K2/EAvPGNowzL9qEOXpwkQ6/MbkDKaRLFA44RPF/FdTsg9JGZhDDnf5sFwTqwrMRjfU463Kd8qDwJAB9xdcTam8G7Pbq3L3H98cfao2dc7TvkewaeEn558634xOlLbD7V4vKPnOL+9h7w3nOkFxewjx/Kzl5cgMnAX6ywWFkM953AhwF0zyzGs1xbR1aVCWgmfUMskGgzAMSMuJwG6CkrHJ6lfZMXSeHtB3hlVJNLJvBAMKtYARbHXKWqop4k2+MorT8YaQWlaCoh2fsoBN1oAEtYLAdV2zCy36UEq7izk5VLIphFRCFkt92IToEV12khQQoGxkhAM4bFrgOoQrebXYvYewGWqN8Xl++YCZwMsgHW9/YHEk39vkGOBtkz/LXRFleG2xTNO/lbCUhwkmQIKVeANsgA3Ti0z20NaM0l4f5vjVj89nNgDHDf/yauP2bQP8akHAHlQiU9f6G0ChW1txTFFdbnSOXHcPdGpGDAGydVjJsCTJHUglUT0iCPJ091YR/uE7Kz8AuDuJDPS6pIYURsHXnNMgvkApOHAHEUyIFRgkdcEtK17NcNxYxVrlUT9J7JANggIWvbkGS2qhD76gJtps8RdRYXO6ippoJ3INUjlKN18J1Z2qG2Z9g+wQziFUchgi8uQf4x2BH6exZxAQz3CvWCwV0D486xf/NMHJ0zEBZUg2hqCeN5QveeRXudgRjB41ih8FVXtaKYNXjNOj61y5QwAdJKUFGeWKUE6XqE4+A4Q2MfADtq5+pwTePIlct6yHV9xc9lqzD+OxCOH8D2NZYZsv3kT/4kvud7vgcnJyd4/Pgx/upf/av4rd/6rYPnMDN+/Md/HG+88QYWiwW+//u/H7/xG79x8JxhGPDpT38aDx8+xGq1wl/5K38FX/7yl3/fX+K2oVqRRaHbFdGci1UCVJF3Kq+fPa+w1I/RO+Sd/DsS652jfnAAs0fNlPJuB377K2ivGTbIzZqywXv9CX6nf4SHfoM/dfZF/Pcf+028+B963Hz7OfD4AczpWqC6KYG8B62XsM8usf61d7F8L8PtUKV1miuD5tLA9bL4FFmc9hJYPGcsnzK65/L+bGXBi0sWbbvRwF47uEsLd2NgLxz4ukHYepVCYgFYAKKH2CbYkyCLPVABGcwSrHI0SPqPkxHVDwZoGWFPAuwiVtHaMDpsrhYipZQsmIH9vsG494iDCPd2XcDipIc/H9Ce92jPezRnA1yT0CwC2mWAMYztvsV214KM6AwaYoy9lAM5EdLeIW6VSJ0MOBvYJsF1EcYxuuWI5cmA5WmP7nSAaRLSaLDfN9gPHmN0WDZSuhqf4T+yxf7jI/rXI3KbMT5IGB9FxMcB44OEcJoRl4IaLCrmU1sNKIoQ4YTRP8zqBmyQ7q+x/e43sH3dYLzH0jrUeU8JBGmVEe4lDVqMcJowPIlIZxHcZtAgczK7MzC9QbxugMsG/trCjgS7l1bseM4Yz9RHS4vsGgw7IQQP9+SaskGqlGYjBGCTJtPHcs0VNKtRA8pSmeUGSA3q/Gc8JcSFEVJwL9clJWmv+WtCcyXtRKvfQfhqk9Bw6liPrXzGsCaEE0J/nzCeEeKKqsJKXBBYicKleivB1wYJ0gKqkUSL+lE0DX2DeG+J8cxV4EhzA5x8HvBfeE/agI1H/9DDjvIddq+JviGxSJPBAH4DrL+0B4/hUMmHVZpOOzRclOTLWmVtTZw5JZi2ndY/ndGXQCeB0E5CCdbKmKVyXs2tNa2ulTNkdV1bc5qco+eVFBGqAkddHPXxPJeKwu2/f4Pb1xW8fuEXfgE//MM/jF/+5V/GZz7zGcQY8QM/8APYbrf1OT/1Uz+Ff/SP/hH+6T/9p/iVX/kVvPbaa/iLf/Ev4ubmpj7nR37kR/BzP/dz+Df/5t/gF3/xF7HZbPCX//JfRrqrl/r1bq8oSw8QOHOoaH1oVoLryb3L3K3aCcxef8yDYC3rD2H6GXORX2YWzx8Vf96+WOLZboUxO5zZPQxlPPQb/B+/7Tfw4jstNt92LjIxpV0gZlfy4pSx/sqA9kICGADJ5CNUtRtoboD2grF4ltFeST8/e4i8TqeZKGmLaG8m1FZPcBsDuzXAOElJVXi9Zq5G24lzYnEhH/NgwXsL3jmxyyjcJa3OOBPyHFlX1WKlNZcGK1B7uYcxjhYxCpijuCyLEECZBai6RLQTsrFsWexIcpDZGZKgBeOoOopUFN2z+nnJ/0OwgsLUaixGi3Fw2PQaZPVzmFaQenOHarIZaLIgHFsGt4zUZYWmF0UIrXLVGRuOEdbA5g2L60+tcfWtXqD/2srLXipWNgzTG9AoCuySpAicnhLBbC3stRMou7YTy3uZwonaCuChAknmbT7IdVGCWDFCrWhDaKtUf7Y9aiVUORZARbbWYKjt09zI+6SOhHgfs/KiBGwh7WzA7qWL4DcEf0VoLgSy729I2t0kgTB1wjkL6wKl1yDppn+VdwZMsHyavkPROyyXonhtRVDXIi2dtB9HIRl3LzJW72kFFYJokkZFKkZGVPHdbEkIy4Hgdwx73U/375yL9apxx/znIzi9/OmrVDWzoHSsEnSwzRWL5gpDwGHAmf1cAupUtd0RlD6AQHXX9nW1Df/dv/t3B7//zM/8DB4/foxf/dVfxZ/9s38WzIx/8k/+Cf7+3//7+Gt/7a8BAP7lv/yXePLkCX72Z38WP/RDP4Srqyv883/+z/Gv/tW/wl/4C38BAPCv//W/xptvvon/8B/+A/7SX/pLX983OO7ZHkf6wvsicwBpvyvI1dLd5GoxkJUpD+AgGFX0jyEQOamIZrB4Ycdb8QAqr4lBsiW17W4uR/HnOrVYvO3xYr1GekA4s1t8fngMTwn/lyf/Ef+v/+4TeGYeYv3ZJehaBDw5RiBl0HoJbjz8b7yNE3wLQC3CiZkyyVGClt8y2quE5nLAeNagv++k5aEtlTJDMVEXskx1+G0HIGRCdga8NOLRpEKwiARmA/ZZVTnKRZ2qigcNpvJ6WOHY7FVPTjNoREL20oozzdTOE96ZF2CElWASNg1gxCcsB1MX20oPYJYWY5G+sgIOyTrD49ECg1Qg3DB4NMiBAC+EbEMZxvHU6syEdN0ITWAhSvF5tEiJ9LPI88LYgBq1C8kGtDdybAiiGNIQkpH3qVsimK0eN9LgRgASMDxMiGsJQnE9XdcURAaqeHM1lwa5YaROuFtmBLiXmVVzJUEqLoGw4npdABLErKpp0JIQSdpzbKn6tQGanzjN+UqXVqsmNirjZEUGqb1gaSkqOGQSAGYB1BhJmiioOoWRzxiXqJYl3fMRJnrEzgI8iQhnr9XXIOoXokOobceuBNUJmMJWidDafSiBUlqE2nIEalvP6LJgx1yNJdkaIARp8d0/QzgR49NmK1JQ/ibCXYlNCg8jYPfwNwlul5AbXxU4sgfCiaAr/YblPp6vQ/N1LB8HlSmJljVITuCBv9e8u5QTYIpQpZnajnJzTMHkiM91J1ZA378m6AWYVkEfZZSSD0c0c0mpgvT+/yVtw6urKwDA/fv3AQCf//zn8fTpU/zAD/xAfU7btvhzf+7P4Zd+6ZfwQz/0Q/jVX/1VhBAOnvPGG2/gu77ru/BLv/RLdwavYRgwFH8aANfX1/Xng4qKDKDqGBUhWKqheNg6nL+2InhmZTLhaJ5W9qHvU8V9E5DzDHk4f81+f/hFmGvQ4Rjh/tsXsIrfgv7eGqeXjItuiV9sPok3PnUFSxmWMv7H3UfxY299Bv96/d/h3fc+jtc+E0ApAW2LfH0jGmrOAa89RPP2S9x/6uH2DzCuDUxidC8S/CbC7gPMPmDzqTPsHlv0D8oFPA3Y3WaaH5hRMtAiZiq6bwbD0gpgYaaFWMnG0OonEPK1gw3S1uECXgBUZQKCjtsYNdPUi/rGIi4zaJnQrkYJEslUZQYeLUI0stAnIAWnCyIksCxlxsVJrUVYgAjGMsKukYXLMnDtJmfgZazSTZwJcbBIwWB12mO37ZRzyjDrICTqnYO9dGg2BmZAhX3LTIVRABnoMpAJZk+gnXxmthK4aRTOFLK8tkLe9d43I8GOE3oRunD7a6mIs1el8owJcKDXY26mxbu5IrEbYWA8k+OfDSMvWSo1nQ2N9wBkWeRzIwaSnKTKSa18p9QWgrRcL8M5VIOQ6xiUMqssE0Bl0W6yikQDNChAxwE2ora4S+sQLDJS/rJHmzIoNxhOrbT33KQEL8AjNaJUQIsdVG1jxdVqRBQ0lHzdyPezYkpQlVcKuKMcT8riE1a5XvsAOAfyHmnVwgSGj7lKS4FZpMf2PcyD+8jna/mbk3vJbwC/E4WXsAYW7xPay6itf3eAUiZrUNyTcxHgtXbKGIAD8MatccadnK98mHTHeBhE+Hjfs5Zg+Tsdz7pm73NXYKwV3O3PpR/8zuLh691+38GLmfGjP/qj+DN/5s/gu77ruwAAT58+BQA8efLk4LlPnjzBF7/4xfqcpmlwfn5+6znl9cfbT/7kT+If/IN/cMeHOCYPJxGynG23SXmzAz9njh/3f+/aR56kp/QP9TUc4jRwzdIiPNg/GZCdldeZwWOAvdxh/U6H/SOH5oKw/91T/MaT1/HG4gpnbo8vhfv47u7LuN9u8eWGkM5XME4yUlxeSUAEQCmLB1hMWL+9w3jeApnRXI0id0OEtGrQn1vRZLPlZtVjYVB16DKLmKmJcgPXAW7tnrKYOAKTQgajWnFQNGLHoe0Xnom4Gka9pokB31NFfzFJNZAygZejQtglsKCAJxJNIA2deTBLcMvZ1OovzVpehRxd0YhlXzMuGtXvIp81RlsrN1bX4pgtEA3cjmpwz4QKaKgQ5ig6j7bX18s6pqK2rDp8VI9rbdUZWWwBWXBZFbqg0PrAXFt0zbUsvkyE/RP5jMIvg8DKvcx/ypukhicFFg2IxUqHHVe339ygJhp01MTIDhXV6vb6vSHXiOvlWKZWv0rS8zxrx6GsZ+U6UoAJRWkLuj2LdFjrQDGjeTnCDA5xZREXpoIxTGKxvDES1EEGeS/Xg4mEkFHblMRTe60cW0nYhMRc7oE5mRkogTiDtr0kxESgPsJfBeRWCM1uG+E2I2jXg4nA6wXSuoUNGeOpR+wMmitJbOJCgB3tFwG/0QByVOVwytWtooLFZkCyst5MHE6DInt3sBWrk9lz7yQuz7e7OFp3jFfufJ/jfQCz9VYD2gdcdQHfQPD623/7b+PXfu3X8Iu/+Iu3/kbH8yTmW48db1/tOX/v7/09/OiP/mj9/fr6Gm+++aa+8GiAyHQ7aJjZCX/V+x9JrZTXHmY58y9pKrpnQjZi0hebDT3rZyl2KwUynzNwdYPl2w7b1+6jvZTs9v/z1mPkB4S8IIRsMbYWnjJyA/SPl2haJ2rqRlsaAGgY5Tgww375GbrdGdiSCPmGiHy6xHjeYjhTJezyNTSoVA8laCGznQRM44IOb2wzOf2WWRAAkRKKOkTXluPcal0WDaqPUZaWJhvxcRJDQEGn5QemvkfVV8xAzlaI1NAqr4gLZ5rsXxgo0HbxWzPSzlOIPnueuEBRhvdMEHUPPSgx2LrIEyBIy9FKq025ctXwMJFQ3uwsk1e4u+jxFT4W5AWdAGMqTB76eBZEYvYSrDhoVWUE1p6aLAaYUboK0t5lCRgAzF6SjtySgG8W8q/uvpMPZwZB/7FDFeMtgB6RbyqtdUzqYVoxFQi+22kghQQCCaTAcK8kZzj8flkpDqRJA1TJQkV0/VYADrEziEsHt42wNwPsPsCGFiY4IRAHEdc1Kct10xhkO9dKhAQSfYytrkcZ0zWprXBbKiwNXtIu1e8dGWZIoJsteL2Ue7cXJ/OUPbLzcNcDzPUOvN2BvENeNvLZdxFhZRBbQnfJ4lPWyXXQXWbYzSgIyiqem6c1SMccZXxR23RH683BdkAQNocJ+1y8F/jqwejrIjIXG5aj59bu1t3V3Qc5//p9Ba9Pf/rT+Pmf/3n8p//0n/DRj360Pv7aa+JP9fTpU7z++uv18ffff79WY6+99hrGccTFxcVB9fX+++/j+77v++58v7Zt0bbtrcfFe8seMsppOrmVHHz0GmAKVsfWArdO4PFj9aQJVJ6sFdmYYsdSkEJzAEh5nzQCTSMBDBBOyG4Pei9hcXGG/syCWiD+yjl+9c0T/O4bV/ixP/If8Ov7NxHYIH3fFb741gqnv7XC6/85ic7hzQZ534M3W5D3gHNA24BeilJ1PlsDzMgLj/HUSkasUlLVPVZtI+rwWgPa9J1l4UqNVi2s7TzkWrmAFOgxCDy5Uk3KYsBSkTQ3kyX68lkEJUY4sdg9tNg/mrg949bDLhKMFV+xQmxORu8FDSym1/lKmwUMUtRBIHB6ZBKhWp9RvMrQZF1IAdqIxFMinck0GbAAmQxXpI2IEYMDj1Y0AxfCRyooMkTAZFRNQhjUytbsJbjtn6iKhKq850WuwrrdM4HUA6QIQyD2ouDBTtGoiZCXCdQlkMu4/g4He2PRvjBy7qwETxO1LRulBVjt7o8uaTMKp6u5IvgbVqAI4G8gVSFK8jFB7wuIx0QgnBJMYvgtYIeMuDTV2iSu5DtkD2kV1rahJA7cMBLLZ622JieEkEmJvA0oeZi0QPc8yPvcSLVihySq6wbIrYMZM5qrEbs3FjKHi4B/h5EaAYAUCghlrbY0gLme4QYNgF48vNye4bcJyAy3GWFvemnLew9u5X5NqwZsCP4mwD69AG+3okt4dop40mI8czBJwCZNYCyfDnj2x5bIXhDA3Xt7mM1e1oCSMCtVZ67gc9xV4pSq2vwUINQ3kKZKTcYbfBCwDgQZ6hhE912rNIbo5s26Q+W9cpr+NlsD5b25VnnlcwMQYeBKXzqC5P9vQVJmZnz605/Gz/3cz+E//sf/iE984hMHf//EJz6B1157DZ/5zGfwx//4HwcAjOOIX/iFX8A//If/EADwJ//kn4T3Hp/5zGfwgz/4gwCAd999F7/+67+On/qpn/q6PjxnlsHyTMZkbm9SnlP+VuGhwCFCcLbdaRlQ9mdmr5mJXBY5F85GZmUH0H0zwe2jtAoYLJ8lCTABMWL9uSvwH7mH8dSivRCttQt7iv/p9bfwse4F/sTp2/j21Xt4/+Mn+PnF/w6rd9c4f7kBxlYMGb0H2kYU7J2VNqKzgJPVofBOKDJsnJDuxTW3LLiCLKMqgFqGzYVHUysY6PVPDM4GvFNdvlJVaXApwdCM2mob1Tpik2GHhPHUi4vumg4QbHMcrOgrCuAiDVYAHQYgyjKjaTJokaRyYgCG0a5GjHsvaMdWlEGQCRxFwb34hUm/EHKONfCQZVgrETJFgzg68S7ronS9dg7JSNbeXBHcVnXrVgTVCJaWFGtrrpEKg0oxp9UpBUHLldlVqX5FUFZagLlRNKiiDAvghKIcLLaoqhG5AfaPUduDdjgMWaY39Vy4vfLMtDop14IdyjUwv89k7SpCt5RYW7aYbO0NVZ5VMZW0+pmKBqIZZZbGcapQ2QmYxO3l/RmEmCdPLjzwMIln1TofEJRLC9BtE2xPSK2Z/gYVywVqy9uOOpeLE2DDBgb1rHYp4gHnnt+Ar66lldcPIGuQ7y2AzLB9gLney/1lLeA94qfewHjmqh+Y24uyRv+oQTiRc7R6n+FebqXNGJWcfJeUXV16qK4f+ukP/j7vJh0EB3P8vHkn6BAVOFVpR4HruB04V5EvwLQ5nww4qABvBd7/rduGP/zDP4yf/dmfxb/9t/8WJycndUZ1dnaGxWIBIsKP/MiP4Cd+4ifw1ltv4a233sJP/MRPYLlc4q//9b9en/s3/+bfxI/92I/hwYMHuH//Pv7O3/k7+O7v/u6KPvy6tlkQAYAqqnsMjZ//v5ThClG9UzUZqCCOss3BG9OuGfO+88Qhe0V5fIwuyhL86J330TxZwz0wQJaZRvYO//XFG7j/2hYfbV7ireXnYMH43Y8/xO9+/JM4/dwKlhno9SayVgwZrQBX2JDs3xmARLPN9UBp2U1fDFW2holqwKqLmM5H2AmfqcLSVfWCg0DpS5YPQMV/ZWEzUVFie7Wp2KiskBVF7tJWEcUGoMympMISgV/hiNE0MzEMQ4zkGfAyg0tFv5EJbRMRBidBoQYr+bLFXJOIkX2uCMmqEKL3qinoxUSAF2koWkawFZuXolLSXrNWsgTSBkFpqWUnx9Ikvc7KceepzVWCvHCXMJFl94xUAlTUk5FItA0Lf2/WgmUAcZUrTJ3irJqGBERkrbT3qNVrrbS0OqmqFKWKLH+btd2KdqAdJjRgea9SzbMjVa2Q/Zty68SJuJu9/D2X+SjpOY+i1DKuVVJq1oas6MAg8y9KwOJ5ADT4ZD8t6mU8Kt2DqQqjjMmxOYhbMkVpR9rNAN5KOxDeAzGKqjwRTEgwfQTteglexoJawu71VlTrkwZFFnj8cGaQWqGqLJ8lUckZBpltzTs0hc971LG5BUibrUkyDpkl57ruHIow0FGAeVUb8KjiAmYBi+5ezw4C3AygMf885fV/ANvXFbz+2T/7ZwCA7//+7z94/Gd+5mfwN/7G3wAA/N2/+3ex3+/xt/7W38LFxQW+93u/F//+3/97nJyc1Of/43/8j+Gcww/+4A9iv9/jz//5P49/8S/+Baw9zBi+1k2CCuSA3eVqDEwB7iizuBW4StuxcCnCKGg+hbfXCmtOTmaW55TX5CmbMo3adeiAtvSwTSOzMY4RPAYYAN1nn8Jf3MPTP3MGtwOWkfD0vz3G/2QTNvdbpBXh25r38KfPv4DPf+99vHj/DKdf6NB+5QrUD+DWi/dXBnjdgYYIeu8l8huPAGY0VxG2z0rQNOjvmdrmip3AlSepnMOFMbWMdJLgSMAO4rJswFeN6MrpHAhaPRhtOUGH+24n8ObFswC7j8itxfb1Bv19I4HLSHVRFib0AphgT3Ctuv4awK8C4qhyTy5XUdw0iowTVOpos+lQlTJISMpEqGRpQBCJy0dbjKMTntfW16A57n21g7GteI4V3ldcTj5T2YvganMdYUcvgVjt5NnNFnIDGJVRysUgVNuxACoEXNqzhNxCz5MEP7cjcSR2BLc11ZbEjEA41Yp2JKSOEE4ycpfhr1wV6c0N11mkLcr1JeBoG5aYBWavc7rkaZJ40urQKGhEzBcz2ud7pM6BWJ5oorZMNbAb9e4qklBOUY5hrajIlutrjEqYAQCxAFJip4s4iydWXGiSkAVynknmpSCP5jqhfTkAmZEXDlFdyAssfjwx0k4E4AiVj9VcB503Rpg+gt9+B3R6Anr9CfjFhbTiU4J9dgledoCzyA9OQV96T/527xSb1y2W72f4TUY4sRjXBuMpYfsRObduy2guRqHUjOEADciZwWESSpAD6aZgVYOcAtLKupNn1dK86ikiCbOAdDC+mAWW+cjlFnqxZHGFbqTr5gF68QAteejkfIu4LAshPqjt624b/l4bEeHHf/zH8eM//uOvfE7Xdfjpn/5p/PRP//TX8/aveMNZ1TUHWgC3y1roSbR2CiQlGM0C3iSkq8EoSR8cqitIFodIIZqJ75I5KNvzMNSTXeD7IA1cYfLfIWvBmw1MCDj/7AKbNzyGltBcGVz3LW5Ch6u0wpYbPPbX+O7H7+I3zu6hf+Bg0gnspoV9cQM834NKO0MFP80QtKIhmCFhPG8QVqJCUDk0zZQ5FympSk4txE4jDstkuZpcGoUfz6sAE4XAWVUYBobfSbXlrweklUdcWkWKYUK9FQRkhPqNobbwcpYPyqoSz1m1EWcVnl1GpI0HBYM82kMH6MLxYhI1D8V3F9kpAIDPsF7MMJMxSHsHGIbvIsiLDUseHLAQ8IYZBfyyeyyml+u3dxjutwhrKSHHM6qKEqhZ/gQmKG1FW+xsIC3V1EgyUWdnGnzki0CqJ23B2pExqkaiHRWwYAnRCCjDjlqt7mnyO9MWcIG1lwoELOCcAn8vn7u8rrTcAKkK3T6DxggsvAQCdVQ2TMj6Orsn3YcEq0RSfaaOJ23CBOR2ao3GBRCCyJpVDiJTJUADmuw4aUW7XpKeuDDA/Ra2zxqItR/OUpE1N0KGBgNul6XaUg8ud7kTVO4YwDmD+14qLu+AszW48WBjEB4uYcYE92ILNB75jUfYfWwlGo0rAtsJzZs6uTa7Z4zVewn+xfZAEkrmQoAYsE3BoWxlzkXOH1ZZJejdIX1XZmB1rlTBILPn3FURKTfsmGI0H8nUlx+NYg4+73z/ZZujEucztm9w+1BrG5btlj7XXbyC2y+aHcTbaMQK5Diep8FOM7Cj/bEigQ7mZsyH2Unhg83bAyUr0qxs8eUbDPfOEdYEtwWurld4e3mOJ+013mqf4p7d4pOr5/hflkBYGoSV7NO+ADAM4AHAotNqkEC7HmQMeOFhWAAAsaWqdFArAJ1PHaDMTBm+89R+0oU/jROXqyIVCwBEnY7tINmt2yeYUdyOxxOP8cRoFl1mbVwX5mKaWLZ89HshI2d1GIaRx6zNSJaBACAQGCJlxSBwzgDNADwsvf6MrI7NUsmRKmpwZqQkbbpoLXyrqzZDxGytVcQeYTwhmGAE3Zm4kmilLSaLbOq0lajcqqpoopDyiSSuVVqSqqI8XqqX4hhsojwHQJ2V1QpvpMpBK8kEMWQeN28DJ8G2ZJ2bUZYkplAcDFTNv7SZy3rDwl2S4CDXuEDPubaLKUlAreAdkouLFA1q4pQMV8aC5fo9Wdut0DEmQSpRUn5YcVU2LQAzVWxspvNAqexvUnW3PUCJBa4O6AyNQfsBiLMZlDqyU9chna+ROrnHspNjS8MIGIPxQYfN6zLMzK4o1lC5xGACob3KaC8D6GaHPI6TJNQMlXxgM3JXa28GRLv1GpTji9njt3dRztV8n/P9HT7vVTv4PbbjoPQH1DIEPuzBiwvaALNsYlY2A4cZTQkkxwPEgrS54/lFZLeU6TLrePU865hXwXm2f6JKB8gp1iqQrD0c4P7OF7F4bY3YNcgeGD/f4bf3T+BNwvef/CYe2xt8qnsP8YRFw20vN487XcIMI/LFJcxKHWBTRn72AoYI+ckKubUC411JwMnNFEDqAmCnwpINMJxn5EVJDlDnR7xxh5D4Mu/QbNhvM9xWqi0KCewMth9bY/tEABqpRQUrzO1EAFShWE6EkJ1WSvIexmQwCtw7i65gI8oXYlzI4oWV8uTjVEV/E8bRqkSUgW3lPTiTVFjaKam8sEDARYP4QOZhdhnBiZAXGSkb0EbIp2wJbr8UTbsxY/F+wPrtiPGswf6hw/YNFemNWskqkba51qpTL6nsUL2t5mKzBfBAjJlr8VS5lVlgajR52BLCCU9t4IQ6VzFpes9KlWDxsDKGxZJEnwNIoHFbEW/OYLgArJ4OoDEjd14DdobzJZBDKxqprAsoqFTaIG2DOkVXLrlo9goKM5Dw56C2MOrhldQvzKjAdPbyFsM5sHqHlHsmxOqiJO/6jGJ+CYYoYuwi3FWPcH8p328fBK3btgJ6MjITJ+/B906w+dgS48rABsbJ5/dwz67lnrp3hv1jj5tPACe/y7WSLvM0E4HmCuheRvhnW+TnL5CL2AKZybcLOEyeD1p9tgrwktqmlGSdnIdkQ3n2UjoQGq9owdpePET6VcBGzdEP24oHKvNATfbnuIGD7QjlWLY7K79vcPtwBy8AEy9i1tM9gH/KgS6ClNICPOI+6HbQF9by+1BhHhUQYho/6y2boxOVJpShcwdD2OK7Q96JIHBK4AIemQn5tm9fgNI9PP/uDidfZGxjg/W3D/j0r/6fcX6yw59+/EX8jf/hf8S/f/od+OLvPsbpb3k01x3M+ww6OxWdNWZguYB59ADIGd1vv4/dtz+ZZhk8LZYSxORzFi6WeCgBeZ1EVFXbdXEULT/Rx6NKbmaaZIP8ltBeZDQvdqA+IDw+Qf+wweY1i/GevG8JntD5SFUeB6ZSBBpcQDAuw/uEoG7HrkmCQOwdxqsG/sKgKdXhKIsjIGCJ8dRgXCXw2YAUJdiTKuIbJytbZhKfMn1/00Vka6U6VZSj9QkxOMBlpKUeqwAES7j4DoMn/++A5mIEpQx708Nd7rF414HyKcJKZlKlZQigts7syGgvM05+e4Nwv8PmIw32DyGKFoMcJ5sgRGStqjJJi8/MQR95QjpmRQdOfCz9ahlwmnSUSq8kDstnWStxmd1JNSWv81upKptNRmotbGIQE9LCITUyP3W9zqVUYaLqKbLSC8qsZUFotlL5hFOZ7aUFkNui8whtjxJomDQb3Q4HlivZy/ysf6A6jTtJCEqwYiPvyZA2nu0N0sIhLteiGj8mUMyiGwoAKcOsluCTFfKqQ7jXgRLQ3mQ0lxH+C+9VXtf1976JzUcM2GS4fuKVAfJdKAHdC63yVGaOmgbVnX0eYObbbJRBzqmA7xSkikdXXTOOuK0c4hRYZh0pMnSr1Thv9XHGFKTuaGOWNfHVMlJHeIISsA4CYZ4C4je4fbiDF0lKenwwJ1+uo6xgdjIPW3szgMYMBj8n4VWV+rKV7MxMF8e0vYLHcJCp2PrYAdlPAxxd3qBpPJprYaDaHvj1p69jvOhwpW2z71p8CcMTh1+2EZ/lN7B82uHe1TnMi0sZAjODUkI+W4nr62YP1ye4wcEOU+VDGconqgdK/qsgiqIrSIZrIJEVTqqlgkgsryntMgCgMYI7j7B2Mgso0Gno+5bDodVFXQAM6go/JX2k5GGtXlkTisHA3hg0V1RFY90edbaUnVQiiS2Ca2AaIS9XSxftW+VoakuyKm/YDFapI84kgY/086mdi4Hw+9gA+wdOrOQT0DQWJmaBV49cdQBTV+xQZIGzSc6v32bZLysCrkDdST5/mf+U4CTHSxF9ulBX+HuWCq1UUSCZP1KWqmQCk7B83iyBrHseRMl+YZAaW2HlfidtwRKIxlML2xiYkJEWhShM8j2JQJ4l+EWetTW1mia5xmw/VSm0kGOerRGCtpnOOwUBmVSB3liAPQpsIVKRX1FWCZkqp4sDVOGFVVuTkIwBE6G5HGD24qklwAhBAKJtEB+fYrxXQChSWbZPb8D9ADQeuHeKq4+LLYq/MXD7LFqLjUD/TdDEIzDMLoCGgHysqnFHgKlb6eKkfJgYF31DQ+Ago407kdLfoPzSrZbkfLZ1HLjuGssAhwHqD6B9+KEOXmQIRLMMoZa3BXGoBGbk2c84PJD1dccl82wONq/e5I3l/wWAcfuD6ctmwRGoGRJYUGy10jIkvzsHGIM87JAvLmBywsmX1rj6ZAMTgPRrp6AHQthd2ICePf7k8vP4o29+GT+/+OP4leffAdef4fTiGuQg2VQ/IL75QCR8ALirAe3CIbZiCWFm7acCCqCZDp+07yRwGcOT1BK0HVSCTgkwdsqKBd6XEe91GE9lkA1ChUwXkEFWGw9Aq8CWAaeyUAR5f1XHiDsH0yUUxXowYPYGfkNormXBzA5oL7kCUfr7otMnrUkHfpJQOF/wEpQ4E3iwoC5Kp6VA0w3DLaJA9aMBjwS7jMiKYCtKGFJhEG4+RthGJ/DtZxZuPwWuZpuBjQ72CyXBKcBlm+GvA8bzDqmzYjVywxVd1z1njPfku0mAQLWymYAyXM9lCWRCpBYr+uaaYZIAQsYTnc+NCuWP0mJrvnwBXi8QT1qkxsh1s8vonu1BMSOuG4znDfb3jQY8q3QIKBWD4fqM1BgMZ1JR2yCP+5tUka52nCELM5CCVlmZ0Ldcr6tyPRaBaRNR0YMmZgVtEPoHcixSJ9W/28u82ESASQjRbshIrRx7kwBzvZfZVVkPiuD1yQqbj3bYPzJYPM9oLxOaF3vk3/kizHIJnJ+h/9g5bj4V0VxYrL4EtFcJ2VmwMxhPGesvAc1GArfZ9uDdroLEqjOFzh0LuIKc8kgLcjonMGeYtp2EwJFQHCtYW5ACYjpah+Y6g8hTMJy3GK09fGwepMigJuHHSMQ7gtJhsDMTYOSbM6+7Ny4tt7LpwT8OGqQcKMxgoYcle64XFGAPTjBsM3nr1L70rLIq6ETNhkT+6RCFUy8ka4Ec9WVa5nMGBxH25ZQBRSHBWvC+R/tfPoczegv9fYe4MHi5Iuw2Lf7Li2/BH118GZe8wi43+Nuv/T/wU3/O439++Am89d4juGc3oP0AihF2SMiNRXi4hn/3Et27DDMuMZ62lV/VXBDsTjNYLzb30oYi4RY5wGgVUhZ7yfy5VjgmyKGhDLRXMtDPqw5XH+8wnqoEVEEUAtPMSwMeSN6XTyKaZcC4bUT+CQAWUdp8PkMR55KTjJNifVxom7B4l10nZE8YT21tp7kdYdg7UJNhugTrkrgqMwCXa7C0fjLVTOrmnEaAeoMUPNBlaStmJ5VZJrgri7DmqguYWgmApC05vxEU5vorI9w+gcJ0HYmySIIZLdzeIjcGYdlq+07beFWhnOA3MlszUQwP40LUJIqfVkGLFuRgqUBBk65l9oSxAZprxuppRPveTmawQ4APCac3gyRAziAtPMbzBuOJwXBKNXAySTux3DJ2yGguRpiYsWytCNvObqe89BKce4O4NFUZPin8vbkG0oIm2xK9xqSFCSW3yw4F1cloruWcp0Yqe6m0JXiUuZ60VwX+Twy47QyMNYxSUTkHWi2x+8Q5hjOhjmxfNzj9nS3Ml59JRdk22H/sHO9+Xwtzuod9x2H9bkTqCMM9g9gBj/6XjLCSxGr1lQF4/znyZlvv+bmqjwC23OSVBQA5gXxT17g8EyWX5SdNnaDShp1Tfl4B+Dj4v+67zq5o/lQ6EtzNt1uA823+9+PnHCMb54HtG9w+1MHrYKPDKml6XPvBx628GXeh8BPm/K66T51/kTM1UNVdzPQQOQHEApWd76NcnACAEuSYcGfPeB4IASCLwVz7xZew+1PcfGyB7oVBjxZfMA/w2YevY2lGWMr4SjzHn7r3Nrbf1uLZH3sTD/6bgX9/A7q8gdkOoOCErNx40H5E+zRh+dijPxdzvtKGIgU9UFQpH13QmcUHy5ASZ5MGLwtw1cWrRRmaG7mB4lkrnkqtAhEcZMZMUtVlbRNmJ79zl2HbNIEmAAkqkP0bLwiPYrdi90aAEDq/q+rkLSoCrrkSgIrsQ2cxNqvyPMSGxWlewfKcSWJM3isDIP18tDfgIDw3OEYhOedG5jrQeQ2rFiCzBLOwkiDk9x55a2B7C7cNMnP5/7b3b8G2JdV5IPxl5rys6177dq515yaBCiELIQGNJYTkkujGMsYRxnrogPj9K0IOiggCHB229QBvqB0t+UW+dDsU2LLlQB3RYPH/UstCwc2YIESjkigKKAoVp+qcU+fUOWdf13VeMkc/jMycOeeaa59TRUF5Uysjduy915rXnDlz5PjGN75RMu1czXPOI0oipKMIspA2bwy+CrDKmAwTzywhpq+QDxTywnm8duxZ7xZ2MRFPbbwBDO8B7JX1bpSID5lUo0ddjgMVGmK6gBl0oQcJ5mcSNjSx8AsOXynAee6xYEWQfsRwYWm4H1IF3Y24bEoqoRPpPWQXG3PPV1h9R7LlTcKyKjoFzMKmBMwNSDF6IGIAc9ZkNAV7pJFVzNAWwpUa0B1pS6QYpDfmEHnBhms2Z3Zuvwe91cf43pjTSDSw8ZSGPJqxfFO3C333GYzvSbC4WEIcJZzsLYDFSFlmLXuwZUcgygjJ1QMY7cIQ1e9ajGoJhhN1AxR6USvgwOXagw1DtrSgXvF52/U0r6NpnJreVSvJo/E9AKw4zZ220228WinwDPk1twklm9rZOTkboND79stJywgsHNfZUuTCgeSUPUS1ugrFgV2yoYgiG28JGJFAHQu3WfQE9sj0k08jXpyHung3us/yBDlDB1+75y7c39/DTjzF44sLeE33KrYvTPC//sQFxJMORiUhnsyZKr+QICVB/Q7kPAMdHKN/tQ8SKThxVrhqDKCcoRijAEqs8dICBhIyKeHV3YVVR5cVTduRBuJJCaME8lHMJAVXOVhaiNHRyBMLT0rWvBMdjSjSXGwSACIDmTJMCABRpFHkEWCV67lWUzWhuonQeWHRXKNzqDC1/wsCG2fF4sJG2/QGAEZHfgiRzSmr7hUQkYFMNMw89UoXItWgjAkgFHM5Eeu8wahA5khwEF93gFkhEfW5KGEXgJqVVinCQEzngJKQcYR0L0EcS5hEYr6jIPzEBMQTg3hcID6YI5omUPME0UJBpywI6zwwJk0Q0iMDtWDGJ0ginhkbhzJILx/avlbQvZi9tUKzoHMvRrYVY7bLg8MXaoz5uI7JR5Kp+GXKGoey4GKrgoCyHyEbcV6fcVW7O3ysMEHaPR/pnLVIMInHtrInoDJm/cUTAzUHhJYohYWPS8AULACsCmLVf4KVl2LR3+RYIznKoW4c8OIwy2GyDGpnC3qrj+xMD7PzNmZ5CAy/fgs4GrPR2ehhcn8fswsC8eYC8vEB1AIouhLFUKCzb5Ac85ygcr5/88x1L3DAlSeklbAzFQJkPRFfuT1M9q0mqio27uaTUNXiBMNWi60182LDz/ki2o8BBN5TGHZxq7OGwWpLUHb/OqWi77EJupPM4//O2vHxMUajEd4q3olIxHXhx6bFb2EVAghgwqCFnpWDHCMnVicqllBzYDk32KpB12SlqKK2rsSC3efh/oA/n0gSiCQG0hQHb3sZ8iGvcI9fZrD5yn384t3fxr3pHgpSUCCciY7xG3/+TnS/3sXFL0wRP7PPK0wiYHfLTmAE8cxN0F1nkZ3pYXxvgmzLVrM1Ng7V5ZL01NOAJWwA4FiRVZKXU4VozgKvOmXiQWePsPUtTtidnlPItoQveSI1xyR0h1AOiCd8RYAiyC7T0KmQDBfGxNJOylhuDi/B9TSCmCtEM64C7Ige0TwwjgLY+rZGPNbINxSm55X3SsavLFmZw3pgUaIhJCGfxXyPZONhLr4nAdUvfH6b0YqvoeAinLCViUXB4rmu9Ic65tiXe9JqwcxEskxPV+Y+3Sd0jjS61xeQi6rekjzmstiUxMgvbkCU1sBZgVZSEhRJqFnuP8t3ehYqJBglER8tIDINihWEMWyUFjlISYiiBLIcSGKWFQNA127weOv3UF7cxviBPvIBsySdTiCfu1o9q5w8zBct4D8XRBzfcyFiVzoGqMXqAPZSjRJeR1OnPP6cbJnUQHLIbEK1IKRjQucWQ1tOU1AnnGMVz60IshSI58Z6gdaI7y2gDmd8n52Ofa8SZPduo+wq6K7E9JxE74ZB79oC6i8e5/PvbGP+Yxdx7Y2JL/qZHgL5BlAMCVvfBAZXckSzEkev6GH7rw4hru+xV2d4XnJiB0JJQCmYuessNw1Y7ykIaYg48gtnKjg+J5KE5wljq1k0SGa1Y6xqAR3fq3UAy4ZppczdCWbjJDWN4LuSCnwOf4ijoyNsbGycfL0t7dR7XhW93OG3CFYWgXcUEi68AWp/wGH9Lh9gdSseq7BRq2IaGEinNl8dpxHEbBott10zdywYkFSUgOHqrhvfnSHbSTHfidC5KXEQbeFTi9fi5+9/An2VYSua4TWdK/iZl13Cl80DOL7axUhvQh3OuLxDlkOUNj7X6UDsHaMzXUCYbUzKBPnAVrUVYCjGALmSTOBwlxgZXyBSWi+Nb94F/snSkRkequ6XV+duMmO4iVBTgbeJwegY/t4IvhhieM6UEmqsWL2+qLwamMBwAXAFC1VmIEtV03IUOTPjhPUqjbHGXFUQoIgIpLRNPhJsuMDbmlJwQi34GqHYAFMkLL5lH2HKHrqwhooASKvkL0o2ukUfEFrAJAp5v4feswXiSQF1vAB1U2bCaQ1R2uNLCTXNAc1GlWJWUnH6lcKRj2AV2gcJaMjSUjI3ULMC0SJnw0XEsdU04fsvNcRwAMQxqJOAYlWrNFBpGApf543Lj9jHKd39wNLwbVKxtEQcC+sK6+l72Mh64e75eW1GI2ypEt6/GLABVBnH+dRQIZobdPZzZFsxSAvWW8yJ31EJpPsl9wkBMtNQ0xwiy0FFwSG1SMH0Opa8woOkewvoPbNA/OwRqM8EjeLcCEcPxKyib8vWjB8wUBkv3NJjjXKgoDsKw6czyMMJKC+8erz3EaStPFGWPt3GhQqa1HnhEBid1xfMgSZiuGgP04WWlNybkGGTzh5KQTW9qLZ2Et3dw5wt+9/uuM+hnW7jFbQQqluqMQPwbxnV4TnXWnBf3r+OIwtpIIRdoQbndedpen+eydOIo7WKAbtVEzEz0se/YlElM0qJ6Oo+RDGCifrIBxEgFLJsgEcGd+Hloz30+jk0SfwPW9/B5P4Uj7/6AcSzHrpKIi5KlsBRmqn+SQwaT4H5HKlSMPEmZBlhFkvY0BdPIHMJSMtwi63wqDIAmLUlSgR1kNh4lV2FssMvubA2wVPoBVUQn0sGJgClsMYCEJFhD8ySRUgLkJY2ziUsMw0+nweN90FYVpqDo7yyhGRWm05Y99A9fkBYtXyGQ4Vi4oXzBN3igmNgdpEUEScxu/uQxN6a8yZivjgiQBSSj69FJQdF3B8cExTINwRkGfOh5jYviAjQBmpRQqeKuysvLb2bx5XupzwpOmMSCU+h1ynr+ZlIIFoYxFJATRJWkzA2dy+JOf5j8wIpFHYOF+Ki6kcn6EsSMJKfGQSq+mAaTERy8U1Z0fNdDTL3XJxxcuPAJ2aDDaARlT6juyZWs5CQOSE9ylB2uVKmMAJqYSAVM2bjcc5eoiHIRcGCulYdg/IcZLqAEnbhwYQTlRtE+1NgNofYGKI4s4HFmQT5kJ8dScD0CGZYQs1jpAe8SCp6zCDsP34ImkxZAkqIiinYQFSQJNXC2y2QGx4Uwnww9xyczqGfL7A0Vy21ZvrPSTT2plF6vgbnTqDI76GdbuNlNAgaoYbhUtHJkF2T5/4zL9MEeDah+5zy3HtqPqvdrnYor7NwAAWRxAwBNGmkTYzZwYJ80kq9QxsW6rXnga5EOp2HR4Zp72I8hipLDCYZ5jtngEOmgR/vn8M336xwf28Pj8zvx4X4AP/fi1/A2V/9I/zP8cPY/GYPWwKIvvk0v1RKAhfOgoa7ABHkjQP0/mqMztkt6L+xhfnZCu5J93kVRQrINw2M5KKPorD0c/AEHE9Ymy89KDC+J0U+EJ60ADA0pLsE3TE8sdvaViwLZY0W8SRCs8h7J0g1aB7x+RYuzlUl2PpYWwmfuRAtwOUxRF2KihQnu2oASadkvUJnGMFGU0oW8tVawkgJLYAyUxwnixjGdC4exYCYWY8xIoYRrScoSukhUWgrU6W4CKS09bFc/halYDHcRGK+m6J7K8bmX96CGXZAkYT46regpIBMU4jtTaAoQb0OylEXxUbk40nRwiAfKhSWhFN2YSdvID1mj0d3RyApEM004uOcjWGkKrkmbUBC12JsrE9YeUv5yF63ExZe2P6XgOna56KYru5gQJ9TKATKQTh5wlc5ZuIHy0tJS8SBAaThhZRjTcYTNvgmFRCzDN2nClAaQ/ddeQSOc8lZDtNxlZAL0N4BSGvI0Qb0rX3QbA55NMXkwRHiGaFzK0d0vOA5YdjH/OU7yDfYAx19V+PG6yXKkQF1NDa+nqD/jEHvRo75mQTpfoH01hz0zLN2TjHLnAQTaKrO55WhsioanNJTwIt/2zQaZheC560wfNFgDzpmtZ/raobIVC+I85zCZOTAm/L1uNz+1oAt1QOzx3IqQbX/26j1S9f0/NvpNl6yzuwD0FhZNIgb4bbhaibMaQj0xbg+F3gAyajmrrtGhhOBlwYVf8mHX8rBMHZF5X5rP3kCqBWlY+8r0EMUkmm9eY6dR7uY3NfD9KxCcgQcPb6N/3Pyk/jFVzwOTRKLOEFBEX7mLd/Ef9t9BUj1sFvcDbU3Bo2nEOMZ0El4lb094oTIeY4zX3gGhz91HostDkSXHXiqeXwkoQuuBEwKLBBb8oq7s0foHGrI3DA1Pq1W1drWpDIRecMlUg2MYwhXCn5hYUh7PIBthJ5Kex6OGXnxDe/+2l+mvmqPJxrRpIAwCZdld11vH0eeRZU+IvjdlbZKtNaSS6po4aFEMgI6t9iWy0EjsByVFpBzW88rYjq/mCr2GlMCpTY2ZgSMIrA14CRbExPHyBacVAwARU+A4gjyaMbG5L67mFgUKZhIgmIFk0Yo+xHygYJOXbxS1ogxZPMKhCEYJVB0BYqeZCHjgUQ8VEhv5YgP5hCLnCtzd1IgSqBTxQQL178WutSJ86ZQCe4mgRdsIUahBYohvLI9E0TC4pCVJiZgPRpRFfqUVmkjLIHiWI2qMBzXEgKm34E6GANFCQX+TBQaImdPS+2V8JXahwNebPa7EDub0MMUs52Uvd2Sy6lMXr4BnYy4SGXClPsyFRj/iESxXULOJfpPJdj8Dk/W2WaM5KhE59oEuMXGMVTf8UUZXeJ7oJDRygC0f1PZ4oWF4YrmPu5YgZYq4+kOxgtShIhW7O/gxPY8rdt+3qx52Nx2TZW/w1Yjb9Sx33qQsz5oatu5QQ8sr6LcLtqw22+TlhkeCgaQZQdRUaKmyOGhxsDQOiaRhRwd+4jPb18KY7hEwzN76HYi6CRFPhRI9yQWsosnzp7BpJfgQqeLTjfHz259G/sP9PDtg3sRT/sYJgoxEVdxBgBDML0OEEmIrASNj9C/uoAqUsyMYsgnDLrPeSXvKjE7Ydl4SlCLaoJz5T5MYg1XbA2XeySFRDSVNi+pUqeXBWCsg8sacZUgK7P44HOnHFHAvR6uFEc0JS4lPysgexGTHezK3UGcppAM89nqy2QEz70EeDq++3En8INAwEOeAtaYOViIjyMtqQXSEjss9MqwKYFifo897dx5JpL7jFIFOdXAIgO2RxyDEgLC1mgzsWSPK+JYok6C6xTBtVpjwjliNo2ghL1eiaijEEW8UCNiuHQZSrJkmyAnz38l/SZ+O5fvR7aglnt27rmJkgVupUsrcIuOoMCmrw9n150u6dprYNp9TDeCOrRKI3nJsbvCQqvOkxAC6KSgfhemE8F0YpR9jsvmfYl4xtsVGwrTc8yYFMRlV6QmK4EmkOwpxGOB3nXimnSxhASQ7mcQx1PO59K3gck8+9j+HxK83PdBuKOWSNxmrACEQgtLNcAQQIaNROX6Mz6Brei+b3prte0q4/xCsAlv10638TKhgbgNJhvEPjgJz+EUOngGDWFdm+flX85wNeFdX7tCAntYIklApqziWkoxRAeAjJUlcrBlsIoJ3WwPW0pmFvFpDIQQMNOZP5e+cQtxXmDzYAfX3raNaA50b0h858nzuNTfwYWdI7zqXi4Y+j+dexQ/99AT+N/TtyEbdbEjgPibY4ZBFxKyKKF3R9A7KejMAPFjT2F4uY/Ovbs4enkXiy3hK8KqBWzVWni9PBggGbNOXLYZ+wA8Q1fE1X0TAqUaKCXEgg1X56bwLDRXpkOUPNM6goDL0wGCoH9I2basNbc6VwvC6FKG6OYYEAIm7lfDwBk+bRU6DJgdSALIJYxUrF4uACEJVEqIgmNcNe1FlyQaWcMXgwtjEiAWCnImeTWfC4iZgO4K6IHmYpbTCBQzIw5WPUIYjg8aW9kdQkD3EshJDLHIgCyHyJmQIYoSYp4Amz0sduLKIBheOBgrryVzeK8rFF0uuwLJUfWZSSV0L4HIu0CZWG+NKwpLHXsol9MhyKv+CwM27ES1hYXTe1Q2KdylRvjSK4afJy9WuIaY03wE2EsPdRcdLKzmYI1EG8+E4NhlPkog5wNIFwu8cYvfJaWAC2dg+il0J4JOJUwq4SooT88xkSeeEvqXp5je08fxfQrzc4R0D+jeImw/NkG+lUItJM5+1aD39DEoVsh2u1jsxEgPS3QvTyGu3oRZVBWSQ9Zxs/6VkKYigLmxVPPCtGc514rf1qjo1hiVjTAFUIu1+1qHcLsJUJtdaSYTN9pqyb0mnOiMbUtMjQjtJ39+7XQbL8doCTqqyhpvbmt/+dyrahDUNrNGx1dIFhICwUrDG0vUafGOGZTn9WOVBQBHtw9iXg0Isl6rp7r4UHkaKlD/sEaQFgvIWwfYfbSHyV0Jsk2JweMxFrsRrhqBp8/vIBYaZ+NjvK77NP7RW/8M/3bnLSh7fZzX9yB+9giYcUlzdTSFnCqYfge4eBaYzhF94ylsH51Ddr6P2bkY8zNV8UiVV6v47g1CZFei+VB6iIcUd73pGoiOBkqB+FAhmrBWnYt11DwFcL2ossuKCSK45bAOVtmzBs95azHTzns3S8Q3Z5g/sIXFdoTpBRms7O0J3MSbBC+jp+VbskapgLKK7ZGy3mNCbPAUBV6ZNWxue80G3p3PJIDImPghbEVoVz7Ee3GW1ADrcZhEgroJRNGxXkVeLXhSZgMWPeljT5y0axcAVvYpnjJN3Cmww8AL+5ILF0th8/UkRJmDrEyRIGbuMeGjkqpyjEAPHVv2JMeniMVzM5vrNIXfXhh4w+qIPcLY2mUL7ihVAHpmh4SFIJ30lJMh88Za23OMC0AJFr999hYnHFtCku6nyEcJyr5C2ZVIxpo1KLcV0mNCPNWIj0tM7+0js+O2f5UNaT4UuPXjA+w8NkVnnKHc6ED3U5gOK6AMn5pB3RoDe4eg+dzHDNVoA2ZmE5uTpPYOhwzkGuIDLHtgNrzgkZfa4tkaiVDSqZnYTCwvVSOQNSG7VfGo0IgFi+6l8zhUKvS0bicNtU5SPqEt6XdV+O4SoaMNTnSfk4trWKPVxKedckZobOyqi5qDsGGUmq35XW2Ahyu0xrVTnrPI6JVDdDo7DCtpwCQCi5sp/svVV+Onzz6FWGgkosS56Ag/cc8V/D/FfZg808VAANFexGyzorQrew3TiSBNCrHIIMZTpADUogOSXZtnBl8BV2WE7p6BzDSrJySNewE8NCeyCNHUla+Aj3k4j4hv2npWQQzF95P936/ICb6Wlco45pYc5qBUId9QPvbmRX8lEyOaxtJdqJO9kspUhiizZTisSr2OqJK09O4h2AsrrcEyledDkr0MElw/jGKCgACBQLETz63KnEg7KbPosahyspSdrIzh2FcsPYTnmIBVJezKQ/LsQDdc7WrdKIYaozDdyBj2SiOyHkGweJCVcnoNOgzgSVkI65kTogU/E2aZWpHeyEqJleRhRFfk0qcU2MnN1SvjoqbWU7WLVaHt8RcGKtOsIrPImWXZ7YCSGIgj6F4E3VFsgG2MzAkNC23ZmLsJ8r60CyGyUk8ARYTeNXdvPGZEaaCmBnKhofanEJMZTFkG2oPgBUZLkjEQTPKNuUgEhuuOYbcTVDKqbZY9s/p1ifZtTzrfc23fp1Ti02+8bsNkWTJGK9xWoYJkPU8ECRSd3QoojFOF9FfnSblkxOB6GD4Es4CC6smVWgf56s7V8flzgoJ0hfAWWWUE3bFMCaM1cOkKenEEWQxx/EDCem+5xOH4DJ7+uTEyE+Fb0/O4t7uP/3H3UfzSzmP43558F0zUxSBVSJ/a5+s1BqIoQd0YetiB6KdQzx5CXLuB+OkSI/0AFmdTr90mDBBlBp0bGWSuAZFUnoB7L9yCTQvExxLxhCc3E1kVcgloVQXvGdahpbgH4Ca3yojx6ptX8Z1Dvo7oeIH5PRvINqSXvnIFNU3EXiBfu6jbr1LauA3BSIIoJdRCQmVWrd3JPSkJIw17Xo7rI8D0fqv2wJCh82wAZeuVlUJA9zWnARiwUT9WPn8J4P2iOSBd7EQIoNRcgl5wcVGTxiytRJXh4m3hn4ssqKqELcFxHDvpm5g/LyMuX+MRjLwAEnBwC8GCAhaqg7AkHPL9X431CraNZ4R4yjvrJCB9uGMIRzDhEisVMcOmMRB5WrpjPXJhS1flmaAWGmpRQswL4OY+Z0wMBjCjPkwawaQRin4E3eFUAVdzTuaE/tUF5udTzHYkFjsCnT3yRT5nW8DinhwiImw8mfDz7sbQnQjJjSnk0QRm/wBIEpsrZslc0IDW0JNpEHbgeLhgNlBdM9DOK9wxFUmL30MdbLJi8l9iEjaO6cZOuG1Y1RhoLMgDjyn0wG4XkvEU/Jb9V7UXwKCdfuMF1Du32XFhYrDTMgwVkm1rsmWazSc1N/bxhSmVgkAQP2uBF6koPXOwBgdKVWM/NvUPQ4aRV6R2Qr8AIAVkrwd66io61xIkh3fh4DVDGMVew9cevR+UGIhU4//zN76EQ91DZmL8j3/7y/j/f+dB7P91H+f//CwG3z6EOJ5CTOdQkxmo34Xe7IGGPVa8XmSInryG4dMRkCbIL276PtfdCNl2yjWTbB0poyxBoG8gcgkxUUgOhc0LEz7+IQygiHz9LQBVSRVHYHAxNAs9yRKIx/DK6NGC0L224OvYHWFyUTHsaOEyExPKHnFtMkvvJ0n8zpOF8TJppQ0NTK58HSmhq+txZUpEwdCR2M5gDFPlKVOAJJiOgSYJYVhAN1pYXUPFyig6rAAdaEQ6yE93gEwJFLfs6xlJqKJk7xhgWnvMhA2SVsjWGQftDBMTIhwrUicuz8rWt7IxsWjBqvFqlnMOVMI3KkqmyuvYCgPHwpMlZAF05sI/O6FZ+oqEJTgU/HzLLpAeaFulQPr9QSwrJq3afOfZDGpeMOw5SKAWEZzMmEtm9vl6xLlY6ZUjVoS31Y9pa8TeqFKY3z3w3ls+lKygb4Ctb825GOtQ4ej+LvIN62UXQLYlkG8Riu0S2xeOQI/sYOfrhNFnvwNs87HT8SFwcx+mtEQQMlxrKwgVAKixgx15g4gXtyKKA0moBruwRtpoGJ2mpJPbZpWmq6/lxJBhs8hu1YLj2uOd6Pk1Y1mOeNbY3FPtm/fzArbTbbyERF2MEPxw3IMK8d0wH6KZzNzc/yShSjd4pPPCLMFDUC1uxb+c0bRq80ALRT/Yzp0vNGRBImIoaVVT9XKxNq1BWQZ1/QD97Q6EiaA7EukNBd2TKDYELi+2cCaZoCdzvLZ/Bc/es4G/jO/C/vEIOt5C70Yf8TNHPJHZc5huDCGtVE1RsuRNliEBQJ0EppdAdztWyaBSlJAAnFSS8wZIWg/GQ1zsDciS4SP22jjJ1jSgKWapAdLYuI7V1lMZIRkbmFQh246wGElWWA/21x0bqxIEQVyFGdK5LXY7l2hMAC0UorxS8fCl6i2kqWzMqixsUM+pcziILoAp/bM0FiotRFUp2hb8BBGislIMMTEwOxMhTSWSSAI0hMhLFvBd5HypmjX8SojK4wogPEFUxY20ZfwTG1E2DoQo41ilnFuR2mG/SljWVD1LW5RSGEdhJ0+UYb1I7sd4Vt2zygnxrITJuHyKZ0Oye4toYTihOC8h5jkTlDRBZpq9nVjyQijjopEOLhR5CRweA3HM1cKTGGazb425HTuRLZGSCqTHfC6KJcb3JKwY36/ipMWAY3flhoboaBw/toMz3yBsPH4EFDnE8cTGmwlmPud6e4rzMmFM3aC41jL515KKQw/IhyQ0Wo1Ug0K/1LxBaoEP24xGK1TYiKWtanciFyUC49fmYa3zvHgwCCGWjIuH92wRutpnflC5lQiduCoIYUcfywoz1a1n52vwLF+kp9q3Fc102/hcECnqAU9XkqXBWkLTc8wyhi+EgLm1h85TXcCMMN9JEU+AIhcwscR3js/ADCUe6N7CpprhZ7e+jXPpMT45+QnoTgfZRge7xzlUweVjBIEliKQEpXx+VWrQ0THM9RuQW5uQGADbHWaOReShIThjk1dMMhNXJFGXcKpyXoUrGyOq0bEF+DjOMbYwoq8FRUCUcbXaYhBhsSWRbTZKaihAdw1LWtlkaChUBsexCCW8QRNO9Ncx9nTlAbL3Yp9BJoHUKlVYaNA/E0uiMIo9DZ/bVDhviwDFSdtwi6DAwC92BEhKQERWIUNDzkt+NkQQpe0zx5gMIEOfb+UMjLBFM9192gVANGfJKDHPWDIpiTm+ZgznL2quhUWi6vNaPTeCzfdjQ6cyQtFjtqZaEOScE+IFEWgUeY1BYTiVQeaar98YiMJwrtZMgjoxRCeGKAzkdMGLKa1BpfZ1t8ROB9TrwKQx8lHCBBcnkSQBHfO4Sw9KxOMC83MdjO8VKDYMRCnQ2WPPvNjSrN2ZGFAucfGLGv1v3QRduwH0ejDHY+7vNIXJC/vexRCwnrBLbQneTV+3z1es4IUnlYWfj6jgEIVwaTZNe+do7qvmqKYXtpTbumJeCzUQPet6hTcG1Oe1pqFeSbt/YQzUSe1UGy8AcHlaobfCqs11dWYqC4goZs0zQ/zQQraiMzChxlg4GCjcR9aJGUbbidYNNl4BOajRGyYX5wIq19xef1jSgI2Q9bACeJE0fDK0p9A6wywZU3fXSU8+je7sLDa7FzG+SyGeCEQzie9GF7H4kQgPdG/hUr6LW8UQUhAe/snP4f86+xO4tnsGncMBujcSqEnO5SDcS6AkFndvII4V5GgAOVswyWM8Q/c7OUyvg2gjhSwTTC9KP+HFY4myS7ZaM8GUwr8X0RRWeVwgHRv0bnJicbaToOhzvaeyK6oyKm7NEQGAQHqdhVfLrsJ8lyWpeAN4ZYdiwwCdShmDrFEDEHhL4QLIEghsHEot4OtEgQCT8mOWEJCZhImNnfz4ImmhWP9O2f2K6tpNxMbceUEwgpVEwMctXI6THYL5hoDuSHT3+HcUs7ahSVlVA2APTNvcumjuXgKOBTpyhdSAmlmvUjJcmIyZ3CIzG4eNIoiDY9sHAnKyQLQY2vOwYeYyJvBkDFlS5eUkApO7GcpUGSCMRL7RZ0+1IMicIAvDsbiI3z2KJHQ/Bm11oBYloptjNlzzHOrZfa5vN+jDbA5RbnURHXFRzPz8kBVUlIP+CLojkW1I1jY07PltPnqIyatG2H91guMHc0T7EsmRRHIIjF9mIDOBwXcjTF5Wovt4ip1vluh/5RLLO2UZzHwB2e+xpxVM9FTk8AwYoBazDucm/97bhbMXILCKFh5NcRqqqCjnfl+3uG2yCRsiDLW4vfvMpQXVYKYA5mvCkzWvrGGYmpyBk7ww51mGWolunzuJid1BO9XGiwUvq8qkAACjawKVd7RKcM0ZHLe6CAyaO58/jjdOgBcAdu6/xbOb4pjhc28yIL1ChzV2QiFYIQVU2ZCRZCoGk4ACac4P4xIvGubwCIPHIpSdc1YiSSCaCzzz9A5+f/pTePPdl7CdTDFQGRYmxqs2b0K8Arga7WLwnS6GV1JsfEdwxdlSAzkhvWF5zEqwcKwUvFKfzRkmVAJRqqDmsVfYUAv2VkjVPRNfRsV6aNHcIJoUUNMCYjPxnpnL83H/O2koJh9w2fliwIUAXayErOHQKTFBw+N+YFagM1iGvR8INq4opU2gtbqN1hMC+G9pizwaW29KaDDRw73Hko9XdgnRxMkZCeuVBJ6VnXRNxPl7ZKnoMmdPlMg/dphYoOgBRnEKiB6mENogmmlLj1dwzERXZdj3lzVcnQMDtbBesUOzS+JY1JxjR0TEFPPCehRKonNjgXgSoehFNvmcIbn0SEMWPK6zzQha2mKSR2RrabHxUJlhQeDMQBYaIrO1woyBmDNDpTw3gigN5Lyw5XtyXox1maBihl3ofgqKBMpRl/fpKRjLapUFoRhIX2uss68RzUtAE/Zev4Xjlwnk2xryOAIMkG8Q5hc1oiOF9FCge4MQjxUG10r0L02YtCIlx22yzOZdikBct3ofw3xQP4cEhoY0uBagkAAVQVHH+gK3tTUZirXvGvGulriThwBXGYsw4Tjwtm7LdrwtgUOs/rsNYn2e7VQbLwC2I1QFyS0pA1SftQZEgwx0d7xaeWz3edvKyh+reiB8HY3rCwyrgwmaDCKOiTmDZhmKsnFdjdhYvTS3G3CcWwIhYaYzmMkEvXu2ACQcQ5gLiJsRFpMhvrOxi1dvagzTBSY6xV2dQ+yeneDW5k18vvMq6DRFctRFt9DAjKnI8mDMKuRxxFCY9wQNy/HMFaJJhHjC/HSXcCrKyvNwkJbLBYOL32SG1cottdpENnYRGC9Y0oaDzGRBtlij8DlIHNexhisln8vl319J/PhFpXghJLExKiRELqCyirru4lx+mDgvSqCCIbU1zE54ODEgKT0E6ONdGpAdAYoJOoz9CYAiqwLihI5tKgCX+7DGiSTKXgw1LyE0x4zimWRKvXRxKaqEku1504MSMufKBDAESty4YjV5kPX448iusHk7eTCBnCWQ/QSmG7FkVCyQ7jG/3kQSYsMWnzRAPCMkx2zYSAhEswIi05CZTcUoNRvKRQazWEAoCdnv8tjJCzj1GKeGQTHXGNPdiHk1HcVQbCJ8VWQQfHpGtGA4UpQcAz16BZBfzKE6GupSBzol6IHB1sUjzG5uIzkidA40kksl4lszyL3DauIOczLte16LO3uSl1PPcV5M4513n4W/m+9vs62SjWr7vja4m58FsOLSMRqfnZTOU4tptcCJ4TGXoMXvD4R4+o0XllcmDtLjiTVw2YMYk1Axr6S0XopXNQtXkga/UE3s2ca7RJKAcg44QynAwQtwp7NQY/C3iEWgsCEbdXlEdV4RrO5cLohb1QUwJv/wd5TnkL0eBEUwsxnUf3sUo5fdB/Hjuyi7CsWQJYWeurqLRRlhf6OHl/VuoSdzXEgO8Qsb38Db3/w1/N79b8a3B/dj65ub6F8vkD4zgbx1AEymDCttDKFHfaCXQKYxcDgGDo4h9w+xsXE/5rsxsk02LMoSsvIhPCVZZYSyJ7xenSwM8s0E2WYX891Ao8/eGsh5JgSV8URFEU9cOqmMGymusaSHhmWZDCAi7ksIgOYKFBNkYqpihyTYA1swozCaW09JszGIZ2xAShvPEQqQSkCDdQ09XT1j/UIYoOzzeBGak65JOIiLK5qAwOVZOpwE6pKhXXyvyq/i/uHKwgJiJ0Iyluz5EJAeFFCZgioUylRwheUFG3XYOFS8vwClij2cY64iTI7s0OsAA/ZyKGEjIQoDdTRlY2MyKGOgDjTURhfFZgdysoCxCbsA0H8mYzizE7GxWuQQx1PQdMrGkgii06ly1Vxpe0OQtw5AWQ4M+shffp4TjgHAAMWAF0kuBlp2JIwC4jn56tl5XyIdGySHJdJbc8zv6mPv1TEmryihhguIgwTYj1FsGMjtHJ2kRFZEkIVAPCV0n10gun4Ims5hFguY6YzJSUJAdrs8dwgB0UlZkcbYhWocAcZUjMJAsFZElmGcW6/IISYWNvQKIGFR2oYnxX/K2uQv4qTav0ZIOwn+o2qecKlAjfO4/2uK8ythwYbRsqIQTjWoRlyjE4zn99hOv/EK8dXw42aiYECKgNMeDFvA/KtTPIMB1dT0cgPCxq54QAUGxV2LgwaMhk9sNs67an+oTh0aWlden/87gDWXPDNlVaVtSY0oguh2IY4n2HhUwKhdzDQv9aNZiuuzHRzs9pDcU+KB3h4yE+PpYgffmF3Euc4Ynbc8gb+6727sX+5icHkbW9/qo3P5iNleRQl1MAZFCtRJYe7ahViUkIdjdL79LKLxFqKLXUzPMsTjIb/Cst8C0VeX4yM1IZ4bzCxE5vO5DADjGIlM8JAFoehxXEynwsd3HD2fbC4SSEAoFj+muX2GJZji7lTsAVTq6X6YQJZkr5mFbZ0nJAxYRSICpJYwEcF0WVWeBCBKCd01EEZCWk/OeVlSgz1gY1XfE75Rssw3B4smB8L3jU4BQbZCcmmrFZfSky5ESUgPSiRK+MRdUbjKyYAoNOQss7XBNHtBlgFbbnV9Hp22lZuFJnSMqU1kZtSF7rLMUrnVQ77JccnurQIkgHKYItuO0bmZQRgD9DoQacIGVylQGrE3qgTkYgTqxuy5aULZj6E7CkVfIp4y1Cg1V2Jmun7FcJQAsg3pmabDyzmkJmRbMQ5+dBOHr88gRMZkmmc6QM9AbxVQPS52mj3bw/AJhZ3HMiR7Cx7DE651Rws2qlSUDIlHkSdcmfmiPqeEmqZBDMnT4TV8zEpIAyob806L6EA1AbR7Nz5PrBZDkn4hfSJESNovjP1nbUiVO27YavBfaJTs30Qgl8IWepme6u+Oi/brex7tdBuvUAGj9fsmS4bqD+/5Nh8Ts/BBU02jue3KwzQGBFqMZoCnkyEIQcvbtJ0vHFwA09sXC/Se3YCJE1AkrQCsQoYuLo12EAuDWZJgFCXYz3vYjOf4ieFldFSJbwzO4WBrAyRSbGOEDsCxgbyA0IbVDJIUkoghxeMx1EGCTiRRpl3kQwAdURkkoPrbVAm1MOTp4rX6nBQaskpLr0xtHpKF4EzEsS6upRXsTlyXS00lTEK8KvaFMIX3ypzIcKiOLqs1DxMUEuHRGJk71ilguu54sMaIWJA4FT5PzEscGbCkUm2BxXR+rQAqAJOIoIwIPEvS5V3JUiBaEADJdagyA5Fx7S85LyCmC5aREoKZg4sMPrE+iUHdFKaXoOxVCckMvfJ5XaFLByMaawjVwrBWYIeNqJoWgBQwFlIsB3yzUV7ywkYpUCeCSRRXf1YCKlYo+zFMLCFKg2IjYnag4pift6ZEPgUDQtRSEKI5IZ4xYSfbjjG5oDC+32D3zBgHxz2YccR5c4ogOxpkBGg/Rfe6xPbjBTpPH0JM56AFE49QFEvvrxPm9ihNc8EZaKH6mJMzZjak4f9fMhS3mYfuhMlXgxdbjNHKY38PBiQ0fquSo9vO8ULMvUE73car6Sq7FsaVajkQFrJrYs3BSsLV0an2DR4UBTGrmp2pcF4fK7N/y07KJbztisvFsjiJz10vw4GebWTIU2plJ2VlDReLc1RbKWr3Edb/oTxneEIyNOnFfKVA8thlbGQXIcsuju+XiMcCahHhsjyD/bM9nBlOcP9wH4Mox8BKPrxu4zLesvkE8Arg/zj/Flzf2MH2aAeDSxMPQYnDMSIXW1QS2BpBTGaIbh1gNDmH+d1DzHciLLaFV5tnEV6ehJIxsUEVTHCAASipvBynKk/KJv5mbOyc/qGDGE3KQsCe/i4IUMQMwLFCekv6bXTfgFLyhktEBjKLoWb1Uhyc5MwTejRnz84lTTsVCDZK5NmLZCtB656x9ytZRb2s9vUGE7CGU1T0+RhYKLAG5IzJI9IWsdSpTTi2sbG8LxDPBNIjMHtwlkNOFqCjY/a6Y06hQGnTOuIY5ZkNlMMYRZ8Nlyw4hwrgY6hMw8TKX58wxDJMB3OIyQzzV56F0IR4TlD7EyCOIHoJokGEyYUY8UxhdLTgBY5SMImC7jLln1MwyMOBuqM4J8+OCYaBBdCXSI5KRBMNNTcohuyZkQKSscHwyQkgJcYP9HHtbxLk9hydbo69J7cQjyWShcD87gJqwNpT4ukudh4lDK/MkVy6xbG3LGNvS0r+scQKmaZcUXqRVbFoIQGTg8AhCWYCW4TDV3SHF9b2hiWA0kJW8VJdrHBeqxmIlu9dazMYLUhUK6zoYputx6XlfdpaTX6qgidXIlgvUDkU4LQbL2A5czwkZzSDhkIAxqpg1Agb8H/XZU7C7+AHbI11CFiDVQT7w3/P1VrttYSJzeFDb8KBCPYvnEJ9wG602LTP+wq9LSM9bCHIqtI7CJUMaDpFfOlZbB6PIPQmsxB7AqKMoJ8Z4Zl4A1fSi1D3T/CKs7ewtTuFAuFWOcTCxPjVl/0/+LP+q/GdV59B769GGF4eorNfItmbQz17yPE+wSt7RBHEIIIYz9H/1gK9ToLxj2wh25BscCQbg2jBAqkkAJNaajzg84iccj1JeCFfpmxbJfaQxq6o8qgUAYWEOohZb89qFDrJJpMIUIe3EwJcAkXYOFoqbKxNQFqdQZUzVKkTJkh48oYEQILV5zV5AyRKCRJcyyvfBCpFCuEV2HXfAJFhIyHJl2ARJTMQdReAZJjRwafOi5MeTmQR2bLL9PmuIU767fWAouB4kiMLKQlhtQyNYiOhCjuxGoLMyAofC/aoAchcQx5OuACmVU2Pj3NEU87f4hzAGKbDklWDqwzj5Wf7yLZi71GVKcuBRRnBRDF0h0kXJtA7TKbG1nbTiGYldCdCthUhH0jEM4PunkY000j2Zrj1k5uY3COQvSwDlQJmL0Fx3EGkOCm9GBl+Dpc76F0XuPD5I2Y5zjKY/UNPDvElTII8UNIGAgVT5J0UnH2HnQEKGb8eGmwwkmuFIYEl6bilhbZ7n0PIrQkF3klMqobKhCjMSUax8b03RifE05b2b7nP2jYrYM3n0U6/8QpbI9bkB0Eo+dTkkzqPRof7lMEDM94orWyhd4eGQXHfw626KgZT9XUDDrT7r0xerG0WGOvG+ZYvk4CihJlMIYzB4HKKxZkOspGE0C5uxAZhnvTxbS2RyBLnu2NkOoKBwPZgih/fuoqtzgx/Ed0NEw9Q9GL0UomeJgiXUAogFCxGUUJojd7VFGrRQdmTKHoS0cIgmhOiqUYxiFCmHMNyMS6vaWgnbqnJwoOBggZV0BpFdnInAeRsUNSCS3M4ooghMKmCyKvCe+JGs88sW9DlmVXlR1Al7Sp4kVl/FHLGhp8fGzT+3ukzsncYnDdEjgU4L87wcUCWrKEdfGnvWXLcShBBS6DsSuhOBBWxIoSvjpwk1WQUKVbfMPyjFsbG9qzg7CyHKI3NwUpQphEwShEdLiBmGcRsAZmVHE+TEmbUg04VtGUCUiShIy5zkvelf0bcz/zcRIxK6FdatmlOiCY2TieFhybd98mYO1x3JfZ/fBNHrwKKrRIyMsA0scr/gO4y9KxmEvJQon8VGDxTQl27BUQRUJYweV6POQWkCv+/BkKl99r3zpMKy524NBu7/21bC9vvebfQwKxS23Dfr4qN3TaVKPDWToInG47E0vHXeV6oe0oh4SJUsWh4J1WJgIaX4x60DAaBz263HzmNQRsgFZHVKdQuWCrr5w7YjX41ZF+GmkCnkDU40F23UDw5tOd5yOp4gCWK2HssyyoXxV0zGbv6Fly+YZFBTqboPXAP1Pk+QDHyDYZslAGGT0pkB308MrkfuxeOoKSBkgaRMHhV/zpe37+E9577b3jY/CqKQRfZZoRsYwO9Z7voXNrnVbsxgDagOOIJUxuobz2F3tkdmM0+Fuc4ZyeaacSHC2RbQxQ9gWJgGXcaftJjuj15qCz0jmQBiMzqB8a2ajEBcqqgMmF/XG4YmM7ujltIEIyvWgNbskRllYemU8FFNp1kFZwHxceRyhLQOPzkxwsAzyDUHWuoJGA61tsCuBimQQVzOoV6CSAiEBkYwYsKmcDCrALSlZMR/EPE8TMmr3ClZWFZryKJQaMBxHQOCM7PEyXHyKK5RHLEcUuhCWJeePaf2NmE3ulhfjbG+B6JwdUUvWcLpNfGEIsC1GO2YbaVWNiWvajFlrJpEcJCq8Tq8oV7H5y3yuodECziG800ksMMxUaKYqiQDyTDpSUhPTToXJtgftcAx/dGKH/pENtJgeNZB/l3h4hyhoKLswVkoiGe6aB/RWB4VaP3zBzq1hikDWh8yO9HEL9yED57TsFcQAZUBMo2ZGp/c5VzJqMYS/Rw724trNDI93Tvb+vCM3y/3fyz9F0wR7URK0IDFrZGHPxEvoDfZ4W3dZJxats3TBHwtb9OPvXt2uk2XoGbD1jD5ctvW2MSqFjYjQCXQFxalkxIPy9Kb5Tqp6ogOwCADMqeeDe/Afnp4DtYI1c23PYGfEmGIJMYpI2XohGqgipcTAw2t4vl0Mifj701VZ3f5X25ZEV/Lxoy7oK+exmdqwnSu7hmVz6KkI1YzDSaAr0nY0yf2kXZI5RDA7ySr8L0JDqda/hf/saf4ujHu7hVDPEnT70aNy+NsPmN89h4qkB6Yw518xDYO/QwIrodiMkMqtRIJQu2ykUJMV2gf1lC5V1MESHbEpURcAtJAz9ZA6gIHbYrTQJr6ATEXLK3lQtP7gBQMQlLhhFLCSDifhS5RDzlkh7O23JyRrKA1QFkd7DQHG/TXXs8DYhScEK000eM2OMyXfjaX0ILyJkExQJOpoli8HfB5A7Aby9K6x0qghMRLrvWE83h1dsBoH+dy9HLvWPOlRr1obsxSEkoy+yjSEIez5Fe20cynjCrbjgEDXsodvqIFK/MZ3cP2BBJYPi0QZQxk1JvdJBtpfX3Q7HhKnrCxs8AZbgfZGkVS3Jja4cBi02uXhzPDNKrOce9EonJfX3kA4koI3T3NDrXpyhHKRbbCZ76lS3M7yohBwuYa0MsDhXLjykg32GXVCwULvzfCp1bGeLDBWAMxLP7oKPjir3r3qRBn4UOsqzdgPDLAke68CxCuFdWWNhRV4tTwC9EAfj4s5BBPDxYdPMiVfm//eI2rEvomMUIDKHPH2siNgKt4uJtRopWGMfm8Zr/n7SPu7dGupD7jk+7hg0r78PHnqjeuQFl02PToSFxrbkiQdXBNU+uZTu/TQ12bF/NhBi5UMEDbmDUpM3KYzSPE3xY/ekMs/s8MM5cvoGNPuWFpfRqyL1DdIoSyWEH8W4X8x1WZS97AmXPqj7MJZ757i7GixTXNjdwdbCJw6KLWBi8vHcTP3/PE3hseAF/vXkW+WaKwZUIg40E0cEcIrMVZgsFZDmgOWFWLjKIjBXT5TRDcqCsIrhiYoNLYi4q1p9nnDkNRMAbN5kLwFiCgxW6lSWqRajd1wnOCtfVJBCNLamisN/bIohqwXlFsgheujC27Qyqww2tV+cZizooveLsk2YGGyXExkkLXznYGSrh6onlIrieSvnDVxsW8MY1HhfM7tsc8rXFnGYhjIacMIFCKI7FIFIQ/R4Hz5QENKtg6B6zUSGAaGHjXrYSQDlQKAcK2tLppbbyUBYCdExRCJfLx5Ak571Jv116bBBP2PujiCsc65TZi8nUIJoZRNMS2W4X8zMx5rsS+QYBkmAKCbmQVjBYQM6A9CDyNd0GT00gD6cMXwsBmi+YNRhMul4izhhfEYJbvRafq2iM5nzgjJp9x5zsXFur5Zjyyfn9Dd9Zj6BQ+7sfTvyBMWsnYKyADNva9wLhtUk/uWtsgxWbHITvsZ1q41UJ8zYhwHCguA4OHmio0dXo5CZLkdBYxbQNuMbntaTA0OCFHqBbBba43x5SbBmAHuoIqyoH1+1rhzXz1rzHaMkiGp4VRRIwR8fA0TFkmqJ7tAW12ES2FWNOLCsFw3lNw2cjTBcjfPNMB5cHm5iMO0g6JdL7S/zC6Bt44+Cv8Z0z5/Dvkzci2+5isdnF4FqC9KBANM4gZznTwxVfh5hlEFkBFAUEeEDKwkCYDop+Vdgy9J7K1L4kofGC9abmAsp5V7ryTqRGjWYdKlAIq44RHwXwYlnleEUL9rhcsrCXrHLDyRpSlqZyuWtsyERhq0pbAoaDFUUJIBKgWENOI69vKKzhckVFVc5SVa7MjBck1s54caeoghl4apLBdGMUGwmL4mrOmYIxoKNj0JzjkfLsLqiTgjYHrB5vc7pEplFudaA7bJySsasJxuSOosMEH5Z/4vvSie1L62WxFiLrHrocNEGEfMSsQmGA3s0CMtOAALKdFGWXk48FAel+CTUvIfMS4/uGmF6QyHa41IwoJJBJ740KDaQHhM3v5IimJdS8gLx5CJrNYbLMT65CCJ9c7AyEWWRezKAe7yrAgUxZJ2zYd9LlbPl31ArzsndF9ffWsZC1W1S685gaQ9Fv1yRu+HPaMX8nRSqBxnzXAh+GqUO3YxUuhVhWGM7wXG2s7pPO8TzaqTZeAPyqx9e/CjLIK1FKfkiVx2Ld5XA7W2PHMxFrLnuDRWhbjZXo2VyK42r+4QUeVRjncoPco4bBg24Mfp9bohQTOyxc6gxYyH6qXZc/sb0eW8DSGTOvu+avyYCyDLh+E8nNPaSdDobDPmav2EG2pZCNuMJsuidBR13MOx10DxgG+pMbr8PXX3EBD25fw08Pn8Rv/OQf45kHt/CNyQV85TOvRu+ZDjoHCdIjjXg6YHX0SealiSAEJ30aAkqD/jdvsKbdIEUxtDWmNEEVBkUvQjFgK+RqMvnkX6dMn8JDhG5F7pUqIgCWiCGKQCR4Dv88VE6I5vyimVgg25AsQ9V1IrRssFz9LJ2y6LDztACB+NAq01tZKJ0wtKm7dhWfAWoW+2KXsrA5XAkfM5oIqKKCBrW9dp2iqnMWCc53mhp0buUQecn2MdOQ4xlwcMSJyVubbBD7fYhBj9MZtIaYE4oLGzaeJzA7F3vPzij25sJcNFUAYkrIB+xtuSRpF98iWyDTXV/Z5TFOQqB7s0B8lEGOFzCDFJP7B5jvSszPCgyeZsJGPhCsHpILiEyjf60AyQSkBIqzGnGX3eLisIOtP1fYuJShc2kP1EnYyxICZm/foxqkGTb3cZawQoOdlM18bqF1qgtuuxIlLv4MRkW82Le2UCXUcpHJ0HCEC9RmKRQXO6t5ZlTF04OQQDhn8cBsMBeB+qI5PHeo0uG0WknUF7ltpK+m4apdQ8Og1ej1ZhmNegENF3DajZdzpcPJuon3Bv/X1OKDIGJFd13x4IFl6DBsNTc+wL5b4MZWI0UBHh4QRJrH42RJXXt5wlILPrfLSs4sQRV29eeLXVq8XkB5BITlbiwBxTAM0buk0LnVQTFMMLk7gU6YxJBvVKoW8aHEletbAICL6SEGaoGOLPCjg+t4+g1buHJtG5MbCQZPx+jdUIjHEZJIQsWKad0W4oGSoFiiPDeCnBeIjhaQ8xK6H7NskObyJ7KQkGUEoaXNmxJV/lUMOIFeV9m3EsRFTQyYYvjaWmXXSkKBqfdllw2jUQBJ6Y/P9av4HEzVpyoJ2bD3JQqBeMz6iFLDq2bo0npnijx7UeaoPBnJUJgg9nR9Mnangg7jnHUdWX2etfniowLR4ZyLiVovirSBiGOg2+XFW6fDhSx7HVCsOK8uksg3YlsdmRmnyINEcQlfI4vhP467JRPydcFC/UmW0mIjbiJeNHg9RQFM7u8jGw5R9qvYWP8qeY9NpwJFX4GkQLER4+iBGNkmy33J4wjqKa4SvnuN87zU/oTjWVNWwhBCQLvJX6lAhqqOUtQ8nfBdW3pvGSGhgBwlpPCIzBIpq3EsXjRWc0htQds8vzuejOrHoRajwhNC8PkKqK7lszbvbXXxycZ8t0qhI1TSWEmlv42H9xzb6TZeAHdkWC25JR7Fm1G908LBtmRcWgZiExYE6g8pMKQ1dlETZvT5IC2rnZPuEYqZh23eWXhNd3Icd72iblzDfBZ3NAEA1zLINEWn1wWwC92VnNwqJIo+bxdNBfStBNfiEb41PI/tZIqteIaRmuN/uvh1/NXgbjyxewZ76TZ0KtHZE4AEokQhSiJIYYPfkQQpCd2LkCxKIMshsxxQfZjEJtRmBdRcIJqVgOh4lY2yAyYOWEhQFuxNxTOr8yfgY2iuthZFxInFEaHsszCuIDbOJrHdY42UgwZrc4mVo6LIelPWcKmFU9OHlzEKJUNcGRGndehFe+1vZXPL3EMwqYBcsNGKZ8zeY4ksg3RvwXDsPAMtFhzjKUqITgqxs8VCygCQxqBYwfQSmFjBxBxnygfOO3LG3UJtZBPGyRrVIAYfzYkXMRbWVS4XT7ACB/eN9AVHIYCyrzC5oDA/RzARoXtDID0gJNaTKzsCxQDIFgJ5n4ki83Pkn0PnWYnRdw361zIkl26BpjPOYbMq+AQwLG5/C6XY6LixHTYpQMWK+JJrtUWoXeTV0l7CTZeRGd98iIDfvxDitycAGblkCJfmLL6R4KQimAdaDGfrPTUGsEOX2o67kvJ+m7mmuU94nJNYlM+xnWrjRWXBxfpCVzyADUNYL1wtLRk8u43fp4lZIxicAdTnhXmdG96aD6Kr+lyWnQTAB4KFAq+0nEBwcNzqRslDHlWtHjArkYjhnyhaipWt0m/0feD/JJbHsZ9TyYxLIgLyHCZj44UsQ3pwCNHtgoZ9xC/fZjinLzG9wDBeOe/iS7d+BOmFGTYHM5zpTXGhe4Rf2P4m/uH5L2D8I1383rU34a+evhvZV7qIpxFkkUKWfQyfWkCWTBqILk9ASQwz7HFi6aJENC9AQkCOp6BFBjGbY3hwHuVmD8UoQbapUOQMz8mSobZkYpDuZTh8ZY/jVYq9K2m7UhYCai5gEkKxZaBT6b0kNWdyBAwbKKdyUXYBR8ooeywB5YyXzLmAZTS3UkcLjhvJEphbAWFnoJyOYmTT4nRaxdtc5WGVscFKjwzSA414XCA6XkCO5xzX2T+E3N70hUhFktjxVQLdDktADTooBzHyjcir9QsD6JiNtE4rz9CXnQEnZxddW+pkatgDtd5WNDecBG8EkmONzrMziEIjP9tH0Y8AASTHGrceTFD2bdLwgGt6RXNg61uw1H7gxk8KFlGODBAR5ucin8jdfVZg+LTG8NIM6uYRJ0pnGfTRuLbo9KkmcQSZpjBZBjObVe9nc7HXjC1ZGF/EgUJ8k0VMq6C1lonYnc/oSvNP1NNewtqBVWy6xZtpU61oYzg3Wy32foeeldvP6SA2RSCkQi2ROTSeJ9Hq/e8XDj481cYLRMsTPVB9FsCDrc+uhku3rFwCo+hdfWewLETnZV7ClQo5gxXXvTvTWMm5nJEw4VG05HW523NGygWc86J6yQDPeDpJXNjzVKSo7ethRyEryMUQiKwnqQ0H+w3Z0idz9OcZKI1Bgy6S4z4mFyMUQwE1V6D9IW5s9vHs9gh7Z3u4uRjgTGeCi+kR3rT9JO7tH+Azg1diYSTyLEIxSZB/tYveLYN0v2SvSwkWlD0c+5iGLEqYIcdtRDEEtEF8/RDx5RKdzSH0qIOyH0EnEmqh+WeSIZl07CTFZVrIFlV0SvWyEJC58nEyCF7xk657HI704Zpa2Jw0UbECPa2fOF5WdoDdvzhGb8TCteO7nPdr41eWSh7NrOeSu1iTQTQ1iGcl1LSAnFstyXnGTMEkgdrZ8gsY/x5sjUC9FOVWF0UvYtWSjvSJ3EYB2qmYaCCeVnR2xyoErBFzjMuMUHYlK9RPeRAlh1xpeXY+wdHLRlhsC8zvLTD6eoRkTDBKYX6WmIgzFVAz9rZNTNh7HcH0NETKRULVtQ7iI4XOHmFwXbPSh+Hcr+hgDnlwDHM8rnQGg7gvx6Psu+ZZhMHErRSEEPy+ODp6k23svGLjvB6JpjpAbWG7hMYEsGRY0Db8ro0dDVSLU6BuuNz1Gw0QVx5ohjxWkjJqxwrCGuHn7lpNYKycYfHFJIP7bKXNm+q+3NchrLhyv5e451VjyviHuCL/Ifws2G+lux8yE9tw3eZx3fOpDQDhx7/TNKzh6dR8qCuCp+40jmkYQJusaYhlT6p22GW6v4cpmsohUkCIqA6zuL5w0jlFycnP8wVkmkJOuugVGhSNkGVMUiDJVYazIsV1McJBt4cr3U3kOxF+tH8dF5Ij/MS5q0ilxlzHuDkf4InZ3ZjvKaQHCv2dCMkxexpytmA4yBjW54skjI1viKJkjbr5HFJJCK2hpjFMwknRotAQ8xzJUQnA0gSl4PVCo4uFho/hOQ9jSSDYfhbWJBNaWGgQHgp07Dv3I2cZbPFnzHckKnV6gXhmE3lz1heUvoijZvbc3BqsUgNlCZrPIfp97pM0gchyzqGzYrvlRgflMMZiK6piWQmzJr3QryO4WHV+z+YkeEq5UYK9Xje0nCqHJhRDBTNU0InA8f0S2a6B3ijR3ZqDFKMKusNBPSLY4qCsnK8TAm0VUIlmSa6bKXrXBNJ9Qu9Gid6lQy5IWdrxZmt/0SLjemNujIfGwzL+nFGrjdvgPaiN6cBjqpEmWljCdiM0W0WSCs4nrOFbFQdqS6dZNdE3t1nyymoX09h+hVcVnGNpnnHsTDcvtsXgn087IYXo+bZTbbxEkkAQw2VhzSzfakFTywhyuRABEaMG+9FyBeSlQQFwGfAmrhu40B7mq+WWoDb4avkkQS0cIUXlxQE1JQ9ndEQcec20tlVeKFuDkJHprom0XZBJn4DpFD0ghA90e/jQwyoRXLkZIQTTkbMM4vAIg/l5dLcHWJztYrGtWPV8LlAcd1H2Org17OPbSuOvj3aRRiVGyRwbnTG2kyle2b+Bt//i16FAmJkE/7+rr8XVR85h4zsxemdT9K7OIY/ngJK1SrxmowfTGwFqEyBiUdrDCcTR2NaOkhCRQueyRHLURbbTQTGRXvy17NXp79JWTCfmtFhJqsrbcuruUoPhPTeHaBcHEjXjFU0J6bFBcX4IoyRMLNC7oaETNvCCCJ1bBdScad7iyrO18SnimBO8bZ04WmQs76UNRBIzTBjHMFsD5Gf6mFxMrOo8w46VlBWhBKvQp0dcKFOW4NpfMw1t86xUTujczCCzErqXABIoOwrZZoQoMzCxwPQC510d/1iBH3vlFfzC5hV84dlX4Mr1LcivbGDzr0uIkjA7F2FwWSDbAhbnNc697BaUIORa4eZTW0i/nWJwmbDzp38N0e+xF68UcGMPZr7g8W29ploLEnZ5/Bsel9AcxzJlRYEvStYXFRIyidn7IgGRpkApqhhvU5XHQYQUUtrVsmF07084N5xEfggm8SX2s50XlvYJ7vmk1i4VF8aaYAd3YCibjEUHFTrjTro2F4XOwrL4edBCeLF2HxIvlDivoKVI5n//7fj4GKPRCD8f/T1EIq4XZWwzPmELDMJKMcwW190/KNNw79GACWpEEFrarvqnggdbaarBOR0lvlV6yjUbFPbJ1f7Frs5RDwQbXxjP7+9aQAoRSrLShztGcB5XsM97Ra4AaJwAZ7ehhynKfozpBRZn1R1gci9Q9g0oNRAdjSjR2Nmc4A1nnsZres/gcwc/gr965i4oZXBhdAwlDL792N1I9xTSfWD0ZInus3PIyQJiPKuEgKX0q3JICbPRgyg0UGqIomRDkRWgyRSi1wUiBSgFvTNEscFlQRabCrrD9aMcSYBvnKE2aXOrXDIuw2nBY7OEB8cKjDKmsCfHDPsxpGggj2Z8raUGDo6YBRgmmWoNCujSMAY0n7PQcRyDhn2YUY/jWKMIJAXKlNUtQgUSWXAyMAiYnpOIp+xpCQMUlkkJVLliXNEayEYCRZ/JE6EySTRlAoxaEIqBwPwCodjU6DwTofcseTr/7LxAvkXQ5zL0NxbIsgjFcYrk2Qi9awLDZ0r0L00g8hJikYMOjurvoRScQL/IIDopiwuXZQVl29iviJMKOWhbbDbe/zY0w79Hbly7FBR3HUGF5NA7a4t9hfT7Zty7LTbe2m4Tw6rNW23zU/MYJ7L/gjkPqBmmOz7GczEfjTh+SQU+hz/E0dERNjY27vw4tp1qz4sMcRmK6gM2Ci+E/EjjoVRSUAEs2MrEWUFlbfHeVu4XNO+FLW3erCvUfs81KKSWTCmxJPrbWIUKaRhnX9W0ZrjKXZPVjENeQO5JRJMEqpNClkOYSKLsKpCIUAyVFXKNoLuE64sIXxWE+VaCv7x6F+jbA+R9QvwTB3jLzl9j8SMx9mddHB/2kA9T9J4dID3qobO/gWRvDpEVDDMRsUGgEiKLq+uS1ri5iSfLgAXfo9IaYt5HNEgQjyMUgwi6w8w3J/7rDZKudPocxOaKY7rkZ0eGiDKrEjEpoI4zT1+HNnytRQloA2PVRiAZyhZpahUfwLW43PPrd4Ekhk5jlKOURYy7gpmCgE8DkAV8yZVoTnBQBAv5snEpe1wRmqWbOCXAJ29HQL5pWH+RgPhAIpoLRDN4qSxheLtoKiBKBVkCi22BxbaVfjqvQV2uajC51Ud0EGH4rEDvukH/Wo702jHoynVOixCyproOrYE45sVQE+YLDZRUdcPltgE4sdjmYzWT+bmzAqKHG+uifozacWu7Lhst/vuEOUcsG7+lmFl4n6sM2AoPFI5F3HY9JxmuVcd9rvDeSUnLJ13D99hOtfHiTjZ1Rkz4G2hZVTSgPmD5Qba57s0EwcCAec9vVWu62IBf0laDuXGdAX12JT0eCL4L4mFlaSdD6T0qB70QyMOIQgimEgf9tmT4Q2kbB78CEND2vmUQ7hM2oVPBHB75UhPxjT5X1B30IMtdlD2JMmUDkW1JlPspnr11Djfu2kD8zR7O/GWJfChx6Z5tvPP8X+KDD/wplDC4lJ/Bp+55Ha4ejbC310P6TIrB5QS9WxqdGxnUcQa5dwgzmQLHY8hBnw1ApEBJDOrETPSYZ0BegBYLmFv7EIsM0WEMNZkg3RyBeh2Uoy6KDS6WaGLhiz2qeYn42iEoYnklSMnUc6uEbhIJURhEkxxiMgfGU9B4AvT7DC9JCXSsLqCUkLvboINDUG6sdJedvCMFM+wytT2NkG0n0AkbVDas8OK3AHtU0QKQBSFLWdYrGROKPifuOqHhogtM7wKKoYGacy7a/G4N6pVIegXOjCboxgWyMsKV61tILnXQe5bQu8nPhBQbdJ0KqDkQTwSOX1PgFS+7jrv7h3hs7zyiIsLkuIvkUortxwiDp2eIv3ud76ssQaXm+FUSc/pHlkF0u3680XzuvX42YjzGzGLBlY3jKCA7GRhdQto+Ja15oaKrOSBEI+q5nn4DUGmCHEhTQygQquz4isWyvngN40jhfNBI3A2PVWMYumM0SB3BxtX9hehRUCewtm0QyF8ikDQ90xpxbYXRazNGjvYeNl/vsHH+VfDi99BONWz4VvwdRDKpP+w7CVr679yyNDRKK9zltgfcNJrN8zcgzBqs0DR4zeCygxjKorafx9idkrW9Hg8nhPfRgBUcVOmhD6s+34Qga5AgYGV22HCJTsoTTFHW7rt2jzZO4TUaXdzCTQ5JDDHoo7hrG9lWwp6OTXrONwSKAaEcEMyoRG80x1vueRKxMNiMZ3iwewXHpouZSXBQ9vHE5Cy+c7iLW3tDJJdSpHsC6SFhcK1AfGwLMx5NuR+04ZygYIFC2vCEpHlCFd0uw3ORApUW79eGr9mRIuIIlMSABBd9dFJXpWZDZYi3d2VIdDVZi4gV9l1FY0oT6M2erWzN1Yh1Krm0ScqqF6SsYoibA5VgtZEMSMcGiy0JGNg6WQLTCwL5iBBPBXrXCOkxQeUGeV9isSMxudegf1V6CDTfBEgShBboPks+Ybq7z7Erk0hkGxLHL5NY7BrI3QzdXobJtQGSfYXinoyrVB9FOPNVoHurRHycQ+1PuU+mM18YE8Q16sxsxukXtmqCj2u5mKuUPIas/mDFqHQx2qjS5gxgOx+j1bqqrtCIffNzb8RdwjhMGxQXvM9+vNdfmto73IQXV5VUal2YnjRnrUBw2mqCtUGcTdJKLazgtg3SjZYMTtucdRIxpG0bO5eVJn/pwoZ1KmjLQw0/b8azgv2XqOVtrY0yuiK2VR1f1gaUYxzWjmG3WzoXrfieDLOqRDgYhBcXrcXeBGrndhjhKiYj72Yp9E5VwB6rqi0WGK4mvm/vV0Bz4N3ds2BpJl51l1yqQxvEANRRj9UeUoVsO8ViSyEbSWTbAnSUoEhj/OnxaxB3SmxuzJBdiFCQwlY0wwPpTWiS6KoCNwdj3DzTx62DIY6PE4yfSdDZS5AeGXRvDhDNNCs9uFVraSo2YmmAooTMA8NWakDalbJS7DFFqjJcERekpDhitp+D/ly+HNh7Iuudoc+eBQFAHHH/RBK6F6MYsodHEaAT6QttaquS73QYvSCvIa8RSMLG6GIg32Rafr5toHsG8TiCygCVG0+Vj+aEeCyR7jP8ZyKbTG0YEuwcGSxGLLuVD2OUAy41k+9qiI05pOL+m14ZoveMQmefsJh2oDIgOSJsPDllozVbgI7HXA6nKH3OYFj8kRc31tC4MetifYYT5X1Jn6X3oBqvvjCraOoQ1heeYczZK7n7STt8GQKvLGx3Av07D6mF3buyNQxlJU/VvLD6OWrnaxa5xHJVC24qeNfri8+mIk/lBS7H+VuvzZ/7hG2acbbvoZ1u4wXUHs7ySikYhA1XurYyCKmttZWaaDl+4AEtrUpaEglDgkcABS4HRQOShgba6L4hE5HLudRXlCEkIpTztALYoLmiCrD42jkcMxNBXktQusGxNkWcrDSEArr1O4DvjWYzYDL1Hp6MI/QunkPnZgrdizC5mIKJEgLF0wmyzRT72z38aRFBCsJdoyNsn5kiMxG2kynu7h7g9Re/iyfzs/jO7Bweuf8uXHt2E2I/Qe+ZBOkBVQrsQeyKKem2GGOuWRS40BCzrBojkc1zSyNQwsnAPi2ol0JZQgslMUSvy2SLJGGosptAd2OwkobhSTlW0N3Ixv0EytQaLGuEXDMRWI/QcGKvMJYkkhOKHi9OdML7FAOWUCpHGujwOIjmEeKZgcwJ+S7DiNGckB4IpMcGgqzEE4K1kACyHYH5GYLeKNHZXmBnOMXLR7dwYz7E1aMRJtcH2H5UYnCtRLrP5UxkxrR+9cweKM9h8gJmOoNMbDK+86KcRyTse6IRvAeOLGHHpTa1xHuXoyXcvo4eL8h7XFSU3kiFRoDFrKU3nEI10JqWiflEg7OqNRiF/BnB51GFn3HH1Ocgd6+hyO9SGMSdI4Q+G96RD2vU87dq73pjwV5pEVaLel4QPE8DtMpje4HAvtMNG4p3IhJx3RA13NOVEkwBdn1SUmEtkdfR49took3osS14GUB0S1h3eL3NVVRgcBxDcEkJJFTyAKpgdmM7t9r08EAIKzp4T3IQPfQaHRzo6xcBS/WN6vGAeh820wJcsqlQiid0S/3ma5eQ25tcQj2NUewOQJFA2VGYn4mQb7BA8OKshjACZqPE5s4E//PL/xzb0QRDucBd0QFu6CGeys/gvx68Al975iKyww7i/QhqJhBPmcbuc7PAihwmZsMkSy4+WTH3qEoLIkBa4kIo4aQTEeRMkS8W6eJUztDAeku+npfTW5R8TbLgGFaZ2m2IFTayTWnp74TOPudc6YRVQIquQNnn40czQjRj2K+wFavnZwTiCV+siYUneJgYmJ8zSO+d4FVnbmJaJjAkUGiFg1kXk70e4hsxNh8HerdKrrqcacQHc4ijCeh4DDObQXS7PP7IwEznFZzn4GbHWg3GU2hYmizZJWj8pHHkRHjtmJadDsKyQuF49UhB08gEMJvfp7mYtdvVjJ7/uMFGDkW/m+xAf5JgXgrP03jnV8JzdrslQe5w0dxs4XzU/Du8praYXdt1r9ruDggbL23YkAhAA1ttbnIHJQRWVSquMYOAKhhp6bos8aRW7G9XL75q6PLKZyV02FzZNOGBNnfd5WZ4aC94yZ1drcGXos4kdMcnYpinjXrsJgGlasdbunWfv2L/TxKG04LJDEIwacKKCNdUD7QGTaYce5pLJDZJOYkjdG50kG91kI8iLK5J6I5AMUgw29jCvzz+OXR6OYbdDD+2fR0GAoks8erhdfTvzTG9mGChY1wbb2D/sA/aTxCPK+X3xW5VekQWAAhWQV5A5fCVmHUKAEFisoBVrAcECTjtRBPDq1VEC6oMhuL8LmHP44xXxVYkwJY/cZ8XfYl4Qki1neQ1G1OREYouQ4LxhCnsnH9GOL4nQrHBUGLZJ+Sb7M2VmyVXcraPP+7nkJLwxK1dzK8Mke5LpsUvgJ2MkB4Rhk9OII/nXAVA2zhWzhR20hpYZJXAoRSstF5oRgAcUhCOnfqAqSAsGyMFwoWWg6eD2G1ZMG2+pRwvlWU7IhC+OwEk7r9vQnWt8e7AwAR1s/y+bcoUwXtS1z0NjEfYF4GQ79K8EKInCEMCCI7VCCnUOmFFiCPc3huweuihfo7GsVeyGhtzc63/vrd2uo2Xa20Tf9hWMWhasOO2Cbm2KiTjoT0A/KK65N+mAW3CAUBrnljbuapjNB5+A4b0mwVSU02vKjRafFmNl9Leh4sVNF/y2srYeaKhseGDt95TmBvmuyFkVNp+E4GSNhEBiwxCcX6W2T/whA/ZSdE5GiHtpej3EuSbKYo+1xyb3+ii7HexPyR89q4NyMig38vwc3d/B9vxFC/v3cSF+BBXNrfx+NY5fHdnG/vHfczHCcRCgWIDdRxZUV32aFhKibyBk4XVNhRsXKIpglpeqKSjCJwrRlZeSrJRczljrAtoNyRrAJVA2QWM9dB0IioZKwEMLhPUzICUQN6XvqjmYtsW3SwIRZ/3K4zA7Dyh3CiBxBoqLSBSjeFoDiUIhVYoCh43070e1GGE7W8Dw6dzpPsZxLwAxQoyK4CbB0CWwRDBl85xY86TkNirkUkcyGzJOlLQGDsrVdlXpbu4/VEZt2Y7MUn4dpN3C5JSU9HwH7pJPvDgAti/OlxgWFrnnyAk4faz70vNE2zkrTYXiK0Gpg2NarbWWH312YmCw817OYHcUcUWb3M9z6H9cBivcEJvGJAlhfdwVRUGJZtGher1aFpVOMIaPnYg8/kqQ7B1bjgAACorSURBVFhVNBb13/4CG4SS8D7sqscnKZcrXPMAOvEt9BLDJG53TingSqfwIQSvYpsrIwG/f1WuHBxrUIqPEUAlPrE6YC/RdFa7P8egDGsWUVEybGhp0dy/pQ/YE4hJEXaVT2UJ5DlSpdDdHAGbG6BOCtOLoXsx8k3WNyw7XXxh8w1Y7BLyHYP+xTFed+4ZvGZ4DX//7Fdwf7QHDYEpJXgiO4+hmmOsu/j84auwn7Fk/iDOcHm8ieN5B/N5AmMEqJSgQkJOFUzHQC4kNr4tuRZXBFDMRRK7twzSgxKX/1bCz9Ow95bvaoheCRkbmIMUJAlyWAAEqMggSUucGU7Qj3MM4gy7yRR/9OhrEd2IYRKCOD9Hv5dh1F3gnt4YszLBJE9xtjfGVjLHRjSHhoSCwXHZxTcPziErIxwe9zD/9ia61wV6+4TuLW1LzBQQOoMoDZcZsQxBaANSksWYXeVhoJbULjupn8xpNoNZhDRpCcgIwkLDCMaFe8dEoqqFkK05x8O0ir1UJYM4zuXe6xrL1b4LrQxf+475uaDJLvR/s+dTDwlYOD5MbxGSwwjOgLnj1/Iml2f9JbFw0zDuwDLU75SB3LW6uoPh9TeIFaK2sAgTmFfBiY1504YvqqKbwfwV5rlWN1sZ4wYPgO/BISzVc2pxmp9TO93GS4jl1UWDBLH0rNxDCgV9V61a/P+hEWJjt7S6k4Fxc6dqxtKa52/WHmvCFMF9uO/rVN1gtRcaL0cO0ahWfEE8jcrK06zF9MLVsEqqz2yRTSdh5ZUIXM5KAJX4c6qk3q/OGIe3FTDGANTvwU12TaizrF4OkSSeji4mM+DWPlQUIYoipJaST90UxU4f2XaMfCCRbW7ikY1N/Pno1Sg2NdSw4LmslECmcP6+PZzrTWDAcZ+tzgw/PryK7WSGK7NN7M17ONOdIpIaUhAWOsYrBzcw0Sk+e+5VMCSQJCW2BjMc/LfzyEcKOlF48H94Ah1VwthOuK+3j6FaYKYTXMtGyHSEkiSuTzeQRiWG8QILHcOQwHHewaRIcf7CAfQ5id3eFNfHQ+RlhL1JDwezLrIsQplFuELbICOAUkBOlFX74HyueAoM54RkQkjGGslRiXh/BrEovEYkiGypkYwXEo667p6DZfN5mTCntuLKVzfGtM8FVMuTo2e+1WI1dY1B510xWSOYroLKxVV6hnVhm8dH2zto6u+ZixlbFQ+fyC/c2GMJqtAjXFK7CNNOQo+zGvD2O9efbrFXR32cKHCd1t4ShvDvXWBAw743hErSvn6c8Br9uQPvsN3LbOwf/u+uoRlPW6rgu4YNl1votq6grZ+8fwN/Do9TW0k0ztfWqPFi2GPVcilOgi6WDkeVkfH3WRmu2j3UdlzG0wOlYPthewwihBFrXwnBCyb78tX2OYGBtASBtNxjLR4RGC6EMRE7wQGoJkRrTPXxJIB4NGSaQnRSJLMR4r0OTDeG7rEUVDFUyAcK2Siysk98zJuTM7i+vYW4W4BIoNfLUBqJg4yNxHSeQglCL86RKI1IaETSYEMscGZrjLyMsNFZ4EdGN/B/370DkIDolXigv4dUltCQzJCMpoiFxkHRAwAsdISDrIe9SQ9KGeyrLsaTLgwJu3JmjyxOSihpcLA3AOYKMpecp58LJDkA4lpi0Zyp6w7OjKca6UEJlXGKgJyXkLMMYjoHZbmtOG4nz0VWEWjc8zROlsl5LqYOMwfPt+Z1O0NAdsJ2yi532prjrNH8uArSNZoL2GDjCgJfMR94BCI4fqXCYYtuhudqNYzB342aec13tJVMZt/t5RDCbeYwd/w2NCf8ful8tPz3KqRoldFpi9+tai8QR/B0Gy9L2PBuflsLPIxadr3/HXpUwJJQJVANCBN4JqE7HhoTxYFqwFVHrl+XN0QqqfKllh5mS4DX/e3iUc1cjmZ5cdMCIbT0n4cBUUGjQskq6G09VCpNlTBtr6UVg3djXYo6DVqw8C8R5301+2TZE67gHqdvBwCIYzu5WtZjlnkIslYfKUkYgtIGdHPPe3WRUoi7HXRtDA0bAwhLn9ajPra/laLsKhSDLpexT7v46/4WVEFQJTAywPHGAAddrhtmEsLXk1dAJwQz0IAW2B/wtf7am76AjCJcmW/hU4//OIgEjBbAYQzqGoCAeD9CNGaiSDwl9OfwFZIvHmkrPcUkDo6ppSA5wL22EKXKS/6uJIAIizMp0sMC0VEGkZcwqU2mnuUQB8feUNEig7HJvma+qEqL2D5zY4yKsoL6nM6fUl7v0j0vn49ldOV1h+iCM36CqhixayqpijUGCzSvHqE16jTy+kLOe+xNJnAIZ7vxKlwx2ACaa7ASGbp0oYbYL5x88nMzdtxkB7pj1byxRnzQHaeJTrhjhAtgZ5BDuDCMeTcMzDIrM6nPG/6ZrIBOWxe9Kxamq7gCq4xmzSlYPtxzaafbeEmOlK9KzA2xb++9rqKGOhjhBI/IwQQOivByTP7Y9jzOkDTiaG5AMVQS6Lk14MJw8NV/t7Mi3b3WjGnrCsvU9glhPE9jDlaunpHYXM0GA3aJpuu+9/EIflm8sQm9KW+g6vv6hGj3AmrtIUbkeQA9GF/Uk7Sp0bO97qIjF4Cfn0hTjsEBnDw8ntgEWQF5cIQkipAmrOTuJKCq3C4BWCZYOUhYqzFyFHiBshNZ4oXCQXQX/qB7N0TJVZR3pnbCI1ZyBzGtPj6eW+NjILOSxYSJ43titqhXJggkkRBF/HlZghYL31fDXpcNVJ6DiCC7VvTXLkbI5ln5tAStPRxscg0RU9WPoeHyBkJWMlZOScVCg+4aK2p6UBfOsXNtnpaH3sl6cAF0zblhkkWXg0VMqwgvsAy/OwgxyKf0zEUHQ0ZxI4cs8Fg8WaIyeADqGoxAHREL4mvVcSt4MJRxq7UWg1VLQQkWxbXn4NCcUDFkhVJQLTYfHtPJSzUNUA2OBFYbrmCxuSrP7E5II8+znW7jBVReRkjAaGt34qqGk3vLZL20UmqDM5rXUFvRtDzAO4EClmJHFUupmshbvM/wupdO2zCQgUGoaSoC/kX2MJBfZFLgiQXnCaGetrhi476EtFWuw22Ca6qpLLRcbw1KDe+hkf9HbrK3cRvnWVSeNAHzOUgGBTmVhHTiw4qNGUoN2U2RJDGrg0QSpCRMN/JeEjSxodOcjyWzEq5EvZzZWlW2rAtfcxX7cSt8k+VsqKwqhYjZiEJrXzHZJQT75zpfLPWvI/S4nDp372iQKECmHn9yMF/z+VFgbNzfTfjOXY+yUiCOYWhkrZjn8rENWmvJuWPfBn4W4aKn8d662FJN6WbVdQTnEC2vef2kJ4QpKKzhR6iFHVY1ar7bQZpAw7CEIQVP0Gr2S+jtNNEN93ctzBF4dET1/Vddq9v2dvT5tlDM82yn33g1W7jicEH+NoLNqgBk4xiuLYloIphEW2ADb2BqQdH6aqSpM+YGemsxPUdS8Dkg9RhTm8Bnq1fUvPYmRu/uNbw3L+5LlvkUrqac6kHk41RhtWYysgZPhBqMFU3e1ifLMni4tZZekFfwSwNKOXEicqKuSjLsaYtoMjvOJkYHydkiiTnBNi8gYu0nS6ej5xJnvdYeANntsLGSAlG3ywaxLNlIagORJhBpCnN4ZI2PZOFg64EQUBFXlGJVeQfDub6XEpQ7bzF4+bWGsbCpv22tITtptap2UFeeA9bzAVBLQnfeK2ycpa7/Z5+DK0Fi9w1L43i2odYwuqxdiwCAOIYUAvr42J6nEfdpkBqabEOvDmPHT+tE68YErKcRwoduHNfWkVQ7Rsiq856PcYuJICQQapI23m2PjoQU+sY1nkR/r2DQNnTIGjBbo8y/ZIYrLNfKG63ychqxsDpDubk4CYydn1caBrfJ8g5Qr5XbvYDth9B4hZhqYyA0SRihSxu44TUMHVimpvrjrRgkIXbfbKuurRnYdX/762zCN24iNytXR62eWOihhF8FLCYPFbrj5HllDBv35CCJmjq9+/x2OR82JkYavCpvwh5+AkKwcq6gQS9X5eJ+QA26CZUXvGajkP5+nLwQFSUIgAzieT4WRDY2Zlf0pPNqgpfCq0kIKSANVXERB7kZY+EvwMwXHm6DIRDpGpwGY2Bms6oPAiaej9nYezXTGZ8zTav4JBmWpcrzuoHxcUAmYJgi8wsGYanp3su2jLqaQoYUzPQjY2XCEla+cM9SKT5n4CG7hYvra5K23ItjqoYpLOE4DEvshF5Pg4hQNz5UGztNGn04DuukqYZ4bXPyr9HCHfuwDvH784fzQVPUNpjcQ+HgpZhTeK2rPJgmezFEFpoKG0LUryWMK7d5Sq5JtUzzDwyyXxS47ULuQBMuBGqLhgrRMXhpx7zIgDt0xYMWEu1uV+MYTW/KHcdNyOGAbZNduR005gd64/vmixB6aOEgqxmM5jFk/bMTDFTt2I3t6gmPwWD0g9wdvnE9IS7evAbXQqMUrNib9xGSQEKIZzmloAUODfvZrSydZxeSS/zEx/WmavfkWHPWaHhlfVPBaWEOm4c27cTmvSBj+9XIqsaZM1imQVgJFwk67LPGOZSqnFFHhgFAVMFEwsWg7Ll83NFNOGXdo/HPoQHXNlVcavCxIRAaxCXHQgyeg0c9nGccztNukRAQGajRv9V1BXRy5+mLin3qKxEH91XLM9SozQnhvSyNn8Y2vGH1ji4px/j/bwNBtj3jZmjhucJojX2W34WWOWkVzR2oG51w/+b3zoivDIEs319IlnteepEr2gt3pBe7OU/nJG8HqHsp7u+wNR9KcEx+WUX9OA7zd0bQ/9ShgjavxR27Bh828P4lpmB4jyFEGX7uv2/cX7B9Lc4TXm8Tk26BPlpbsH2V6yI83Od/RKM+me2/WlJleL1kavsveabB+T3mr3XtmTtKvf/OaL9SrQxcJdoKKSxVPGAshh6MS66urYJNFdCXwT1ozTGpxrbu2j05pXk8F99pehn+nuykH5amEdLCpMrfs++7KPKwqZdfMgwDL0184YLO/19B2t7Dst5rszxOc6w4Lyhk8/n9nWZmOMG3LEralDTCz1u/bxy3dm0qSOI3Le/JCvRE2P3C57f0joZzQSPmvSTv1mZQwsXaqnlNyJaFLepzUjgPuH0a97LUwm1rc0pwnd7bamknxfL8Oczq/Z9DO92eV9javBa7gqixgNo6rSm+GeqTuSYcO6plVdZw0WurOtFIaHYP1+i6htnS/QQ4t2xO+MG9UjWh1rL3gwmqhrPbfB5/XBe0NXr5RQr6EICHe2qTZXPV6eDQ4MUK779eqC+AaUL6NNX3b3pUtVSCQGzV1yezsFEt+Vk4ijRq8JXrT9Kos7KEBE0m9RWknWhNlkFEcRWnCwy+WWTVwsB6FjISbNBKViOpkVOI6rnbjo0H1IkLISvMJQZLp3oCfw+uL7zBsp+ZvGBI0O4vogguATmsi0VGBgzOysMSUcTHcH8vFiA6ob6Vg9pd/FUpjjvaxGaQLX2iqzHq4qM+riVdfKfwfeXp9j4GbZbP7zy0hlcZMnI9UcduH8Zia2SlRv/WiEn+dA0IE6jBdeHxZBJXsGEN6hQIkQKfjN9AjrweaQCbL81pQlTvs3tHQ0NWY3uuMCKrFqshmtUMw6B9AdNkZfpr/B7t13PyvD760Y/iDW94A4bDIc6ePYt3vvOdePzxx2vbvPe97+Xgd/Dzxje+sbZNlmV4//vfj93dXfT7ffzKr/wKrly58tyvvrk6WPEg6gmwovK6mquccLXpjl8dpNq/9SS0NFBrq9iah1a9cK2GK4hx1Vbezclcqvq2jZjAyty38FTeK2yBXoWdyJpxrhZoyZ9fyJUwX3Vv0i8oQsNYW63WoBZd5cUswRktxjMghLj9Kqo+1dhoq0gtoafsY2UOTgyID7XrCRUW3Mpc2JiZaYyfYNw20wiIiL3AwHhU8ZsA/tSuPE09VuOMrE88FtLT4ako7fnc/g1ZsUZr64fwPjwsqZR/pmzYEzixaDaykhVRorj6vvWEwTl0pa7B+0WV56MqAo//zPVB8B646/ISayEEWr9R71GF702TPNUWp1u6/gBt8OPGH8/U4dqm8a3FrlbMNc3tfL815ja/bWPsuH5qnkOIk88Z7ue2D9GdNiSr+flt5urn0p6T8fr85z+P973vffjyl7+MT3/60yjLEg899BCm02ltu1/+5V/GtWvX/M8f//Ef177/wAc+gE9+8pP4+Mc/ji9+8YuYTCZ4xzveAd3CinvObYX34F6yuivcFrup/q4lITY9rlVxtuCczQdUO57bJtzeH3sF7Ffbrp6suUyPbcA9YSzPb3LCAHLbhZDnkgcUnq/qs6UJr3lopZauf2VfNe6l+Qxb761tcrkNrNX0sv2k24ClnJqEaC4Ygvvyx3TXJRmSDCfO2qJhxXP2Bju4zto4BtonAQfPuvfJeWEhgYFMjVjSNLqtzZJUPD0+fH8s/OmJIO7He6EVnOl+3LhdYt2GJIrgvOGzd/3fCse39VXLO9K+cAzHuGmQKlbEetx3wbhZ1WoLlZYQA4DluHpomGoHa85Lsv737SC8JjnkTiC/2jXdJkRzJ9fwPbTnBBv+yZ/8Se3/j33sYzh79iy++tWv4md/9mf952ma4vz5863HODo6wu/+7u/iP/yH/4Bf/MVfBAD8x//4H3HPPffgz/7sz/BLv/RLd35BZODZdv4Bt3SWG4Rh7RsH3bRNwhY2rBL4VmDYtXPZFVQIi/lt7HfhisoPvBMm2lWTsZ3Ea4K74b00PxPBSy4aorlttHx3DjIeXvHxAXdOB636hQBqq1sPUTn6cNi/1OiP8F7dZgGNPlQjqWJ1QeBYBGreoTfl0wmMhxJBgUEgA4jYX5+nSJOp6T8CsOQNAkiAsowTlhvnbUpqsVek/D07goKIIh8XE+5eTWVQIKSl70s/2ck09flcQklWHdGaYcqgr6kseD/3WKIIiFndROq4giIDwyiE4KRnYcVmgRopBN7TkUBR1CFId04HzRuqDLsjqMQWapzN6p6PaEDirt8C5RkyfK1+YeDHTjV+hHLPneHCMPE2vLal8RX+v1Srr8VQNRCZ2rsTvAtUluxZunknNA618RqgDW3zgJD+3W1Py2m8V+ExGkzGWpJzOF82iRruWOFcWlO/Cb2s1e/vyu9foHgX8D0SNo6OjgAA29vbtc8/97nP4ezZs3jVq16FX/u1X8ONGzf8d1/96ldRFAUeeugh/9nFixfx4IMP4ktf+lLrebIsw/Hxce0HwPKEe9KqJ4A5WmFEqSoYbqVH1PBAGueGkPU8lDaPrLl/CCm2bROSQMIWxKKWrjE8jhMMDiCmurfiPB9T+xFRXDNGK72bxn5wMI4QNTae+xwiCJK3PL+mh+egutrkVoNdqNou+LsZh2jzPCEClQfUJ6NaMNsEcJshD4fxJVI17kxwLWFr9DcnSZsKSgzjmQ0iho9rhUxBR023BBEqypbkYu4PkxcsBTVf8N9F6RUt/KLEwpSO6OLiUqHsFrQGigJOOsofR4q6YTHa1/kSyvaL1pXhCtGA4DmGsKN/1u59dP0cwu3NRVf4DIMFUtNwrSZPrTCmbj5owJHhGFo6Xo1wUc0ZocFeaiGs1pSaCuJvtfkpmLvCFAP/d2CglpEZqm8TtjbB8BpiJWrnrhtB9w6fMPfdDpq8w/a8jRcR4YMf/CDe8pa34MEHH/Sfv/3tb8fv//7v4zOf+Qx+67d+C1/5ylfwtre9DZmV6Ll+/TqSJMHW1lbteOfOncP169dbz/XRj34Uo9HI/9xzzz31DVZ0RsV6Cybo+gb+gYQQ0YkG6oRWjwm0HKNt4DZjVqEheaFauKJquebWlym8lyak1vZ3+L+DlhrnqV3PCfcnVp27deOwz6tz1KGoEKaT7dsEn7VOMsE119iTK467xEIL78PFnGhF7DDsnxWQlxcnDuM0ZJbuG0DFEDRNppvz8Jb7wZ/Peog+Ducm8eY1hvtaT9KNgZXGpgWqDf9f6v9V4615zc39w8XVCfvXztVyTUvw+YqxtASDntRaIMGlcdn2/gUQ+iro9I7aSX3a2mcnLODDfdqM1As5p+F7YBs+/PDD+NrXvoYvfvGLtc/f/e53+78ffPBB/NRP/RTuu+8+/NEf/RHe9a53rTweC7a2G6F/+k//KT74wQ/6/4+Pj9mAGb20UqGSAraSQFizym1TeQHO/Xdf8Wp1ScXCtqb77rZz+zpFgpriQfBCNcVs7UHhIQT3dxm+hMGqxkIGSySDtom+zT0X9Un5xJjX0kpeo7mKXLo399L5iY+VN1rZWMJ5FKZ+DN8tlZwPP6/qeh1ji4qyzt4SgcqAUvzshayVshCxqKA5Oz78ed3q312q1hCirVYv/P5LzEB7zVzHSlbsOmeAfIkKjfrq17IhnSAs+H6Fsv0Y6uwRVdqERL5KtY8f2fEg07Si/5NVdg8gL+/tKAWhDIS2uWohNOto8bJa8TvWnn/WoYcQePrQ8OPGeXFNcVvfl8HCoM5Oc2NJeaUUAJCdtIIXRaUn6GvOxRFEksA0asn5FooG+/dL+z7y49lQBSEr1kx06RZe61SzXJeAZYFGUb2as1fqEMsLkfB9tMetVTj3m4ng/Ki96/zcqwVqTf8QqBYx7vksxdSk9345VtvGPWjxPEOoMpynADTLH4V9/EK152W83v/+9+NTn/oUvvCFL+Duu+8+cdsLFy7gvvvuwxNPPAEAOH/+PPI8x8HBQc37unHjBt785je3HiNNU6RpuvokwSqE6eU2ztKIWwBoTLxV4LSioK6mbNeNRYPtExx/lVFwsjUAAvmetppjYvlla8Iawb3Urq25T+Pa6hfUOHcDrvPeg6xUF3zsy+c8xf7ell45q2NXU8NvQBI1pYWQCAHZoJDbgoZWm1AIwXEfpSCMYQp7QFN3ck+ANSxuIirKKl4T3reD/UJnKYi9MHsugELttZq8UtoPVSkgRc2ohMbf94cIVvNUV0hwk1XtWQVjthY7UsoaTe2ToVvHVfjMyXjqem1R5t4jt/Cw7EwqygpGdrlyUrFxtd6bcH0dwrpu4izL6toQjAmgqhMXPA9/Xy7epVQlHg14hQ9u1b5uAeoVP8LqCkkSpEiIYCHbEncLja8rshrGf4NkabIqLe59aSru+/OrhnpPAD3zYjowBuFkH0C5oaGvXy+q4zbakppJm0fUBi36A7j5qOlpV/8vwa0rz/XCxLuA5wgbEhEefvhhfOITn8BnPvMZPPDAA7fdZ29vD5cvX8aFCxcAAK9//esRxzE+/elP+22uXbuGr3/96yuN151dnPEPYenvpU2DbVYej+q/a5+5Y7fEoprXBCy74nfSanCisIep/+bDtZy/DQoIPluKOa24jzZacC3W5O6ngc3X2kneXbMvLNTkYzDB3xXVXNYgKVazoOp7e1y/rzN0QlSeYdt12PiNp9eHYsDCUr3t79b9qf4iAwh0CI3PP3Mrev+3266BBiz1i1tMtN1DaMjCywohyRNgpdpiyF1T2Mfu2IF3tHQMqsOEreM8jAmugPBqY2gpTrMCXq0tXv0F1Yynv6emx9dyDbXj+lO1jOMm0rHqOmvnELX3eemZ+sVDIw2mrbXNPSdBeq3HaLnWEMpszEFL52oe607O/wLFvJ6T5/W+970P/+k//Sf84R/+IYbDoY9RjUYjdLtdTCYTfOQjH8Hf+3t/DxcuXMClS5fwz/7ZP8Pu7i7+7t/9u37bf/gP/yE+9KEPYWdnB9vb2/jH//gf47Wvfa1nH95xCzu3zcj4/4MXuAkhNGmifoUcwnW3GYyNc9WSB93h3eqntm/wkA2vxPkzXX+R3LY1jD2sd9S4b4EaBCCieo6Lv84otvs6AxAu1U11bN1yPfZ8ntkVriJlIAuE+mQWrtB8MrM7nFvt+v6oni2VFfRksqy6njDoH7AFRXAtsArszkOrwZr+WRWVTmCYROugSBVATM6ASoYwKxagqnuP0nnhmkuTuHvJ80qlw8JgIrYq9kGtMuE8Mtd/KgFT4E0FJwrhZamcriFfqwJ0DpdYK5KqppOD5pxH48ubOEKN9XAoD8uYVEnKVbVh61WFHk4IS4XJ/w0hgIopaCWtEBCpQog1eM52AAXjqCWO7QyWW5BJVY3lIq+RbZoogh/HtRhTZbRrBtZUEGN16hC+q8ITbjz5JH93jPCYgZhw9XngndoFTg0VarYg/uWTnANDGbJz/TUGsGx4HH/9IdKz5FUFSI121xR4juHc3CSS/aC1Df/1v/7XAIC3vvWttc8/9rGP4b3vfS+UUnj00Ufxe7/3ezg8PMSFCxfw8z//8/iDP/gDDIdDv/2/+Bf/AlEU4e///b+P+XyOX/iFX8C/+3f/DqpNruROWhvEBthJJojVtAUfgUBRI/C2HJPGhLGoBs101eU4r8YaEQ+11LZpXI+LFTiVh4aRYDy+Gngh3NSG53vsPooqZRHReNmKoD5Rk2HU7LfwZTTWKDf6s0aVD17CMH5VfdeEMmQN4vGf8cX4CY0nVvuSaKvGoE2NOu0nP/csQi8q9BJ1/bMQlnI1yPxGZVkzerwDwejSayBSWXLMSilW33DGwv6PYKKs1cfy3o7xxgUi9jRvty97j9Kz/5xXKi2k7hcS3qDzMyetqz7wsHXs76GquZVz7CbmOmh+stSASOKaV9bsz/rkFPxtr8HHdYN79giANjVjVpfJCoxEMKmGizyvtN4cM2gxcsGiqPZ50yi6W2lM3suK7+FkjepY9p2pJvXgd+24y0za5sTvaPd1I4vl2JTvq+rZ1wxesF3tHsIW3g814m+04t7dNS1Bno3tw3O8APChoCYt7BS04+NjjEYjvFW8E5FMlyf6VS5u2GknYbFhfCkkUjQHwapzBedsvrS8X5ur3mARuWttiVvVc52CWEXbsVuNduBluvttXnNzggqNJlD/3u+6IsZ2EvwSrvBq0lFUxRqanl9wLRw7NLV4YtuxTzx/eL0roN4lua1gxey8k5rkUCN+KDspfCmV4Jm56tIAfAzN3RvpQM3DeUfWgNVyw4I4V3iPoZdbk8xqbF+PRQUajwg8Amsg2phty+9FA+loG1PN7dwj8B6uafdUnAfvtrPxuVBfsRbjaYPsW8ZJExlpGzOtc0DLfdb6pDm9NksntbWm8XJeevOempJuoRe1ao5Z8lSD+bDpkbUat9vMea0eYftxSirwOfwhjo6OsLGxsfqYK9qp1DZ0L3tJBVw2ph80ZQm/BAq9DdKNxL3gAS91uAAggzL2khXI/bMNIDbC6odJ4KKEgF19qur6G4ZUyODloYpIAkJNCJaPIQFh7ErLTk5xspxn5GM5jXt1wWME9+AHpWRmm7tXHzdxL6Y1mhS80D4OVjesgJ1YXCFEKUBlXr8Go/05CSU8lEBOfV2CqIC/IKd9567bkjg8e2wJIgYvCEV9/yUoxI0R/3LLwJPUQKh7aFAl5VLBcKQByGgI4TxoHeguaoisgiNlJ7WP3kAIyUUnATYQZCdhe83CLc61ts9F8HfhJOqJP01oLbKrZwqqA0t2coOqwP64AFCS99SZHWifjzYgnQPGwbeqem1kfaFDrvaWrD9fRCIgk+j6e+d0QU0JkSaANjBaQyZW1ooCEggA4aFcw++YsOclgpCOaBKgB/bahN0nhLdBBsKNaWeEgpp15NGXaPn9EhLCnxv8Drh3q2kEiADdqGrcBq0RVfMTERdV5QdVncdthxYExjJol7w4NGDDmufWmJ9CWK95bcvUrOU5NNyeGp+7+RtFcL7n3k6l53XlypXlXK91W7d1W7d1O3Xt8uXLt2Wtt7VTabyMMXj88cfxmte8BpcvX35eLucPe3O5cOv+aW/r/rl9W/fRyW3dPye32/UPEWE8HuPixYuQUrYc4eR2KmFDKSXuuusuAMDGxsZ64JzQ1v1zclv3z+3buo9Obuv+Obmd1D+j0eh5H/e5m7t1W7d1W7d1W7cXua2N17qt27qt27qdunZqjVeapvjwhz98smzUS7it++fktu6f27d1H53c1v1zcvt+98+pJGys27qt27qt20u7nVrPa93Wbd3Wbd1eum1tvNZt3dZt3dbt1LW18Vq3dVu3dVu3U9fWxmvd1m3d1m3dTl07tcbrX/2rf4UHHngAnU4Hr3/96/Ff/+t/fbEv6QfePvKRj/haVe7n/Pnz/nsiwkc+8hFcvHgR3W4Xb33rW/HYY4+9iFf8/W9f+MIX8Lf/9t/GxYsXIYTAf/7P/7n2/Z30SZZleP/734/d3V30+338yq/8Cq5cufIDvIvvX7td/7z3ve9dGlNvfOMba9v8MPfPRz/6UbzhDW/AcDjE2bNn8c53vhOPP/54bZuX8hi6k/75QY2hU2m8/uAP/gAf+MAH8Bu/8Rt45JFH8Df/5t/E29/+djz99NMv9qX9wNuP/diP4dq1a/7n0Ucf9d/983/+z/Hbv/3b+J3f+R185Stfwfnz5/G3/tbfwng8fhGv+PvbptMpXve61+F3fud3Wr+/kz75wAc+gE9+8pP4+Mc/ji9+8YuYTCZ4xzveAd2mKH7K2u36BwB++Zd/uTam/viP/7j2/Q9z/3z+85/H+973Pnz5y1/Gpz/9aZRliYceegjT6dRv81IeQ3fSP8APaAzRKWw//dM/Tb/+679e++xHf/RH6Z/8k3/yIl3Ri9M+/OEP0+te97rW74wxdP78efrN3/xN/9lisaDRaET/5t/8mx/QFb64DQB98pOf9P/fSZ8cHh5SHMf08Y9/3G9z9epVklLSn/zJn/zArv0H0Zr9Q0T0nve8h/7O3/k7K/d5KfUPEdGNGzcIAH3+858novUYarZm/xD94MbQqfO88jzHV7/6VTz00EO1zx966CF86UtfepGu6sVrTzzxBC5evIgHHngA/+Af/AM8+eSTAIDvfve7uH79eq2f0jTFz/3cz70k+wm4sz756le/iqIoattcvHgRDz744Eum3z73uc/h7NmzeNWrXoVf+7Vfw40bN/x3L7X+OTo6AgBsb28DWI+hZmv2j2s/iDF06ozXrVu3oLXGuXPnap+fO3cO169ff5Gu6sVpP/MzP4Pf+73fw3/5L/8F//bf/ltcv34db37zm7G3t+f7Yt1PVbuTPrl+/TqSJMHW1tbKbX6Y29vf/nb8/u//Pj7zmc/gt37rt/CVr3wFb3vb25BlGYCXVv8QET74wQ/iLW95Cx588EEA6zEUtrb+AX5wY+hUqsoDXHU2bES09NkPe3v729/u/37ta1+LN73pTXj5y1+Of//v/70PkK77abk9nz55qfTbu9/9bv/3gw8+iJ/6qZ/Cfffdhz/6oz/Cu971rpX7/TD2z8MPP4yvfe1r+OIXv7j03XoMre6fH9QYOnWe1+7uLpRSSxb6xo0bS6uhl1rr9/t47WtfiyeeeMKzDtf9VLU76ZPz588jz3McHBys3Oal1C5cuID77rsPTzzxBICXTv+8//3vx6c+9Sl89rOfrRVKXI8hbqv6p619v8bQqTNeSZLg9a9/PT796U/XPv/0pz+NN7/5zS/SVf330bIswze/+U1cuHABDzzwAM6fP1/rpzzP8fnPf/4l20930ievf/3rEcdxbZtr167h61//+kuy3/b29nD58mVcuHABwA9//xARHn74YXziE5/AZz7zGTzwwAO171/qY+h2/dPWvm9j6I6pHf8dtY9//OMUxzH97u/+Ln3jG9+gD3zgA9Tv9+nSpUsv9qX9QNuHPvQh+tznPkdPPvkkffnLX6Z3vOMdNBwOfT/85m/+Jo1GI/rEJz5Bjz76KP3qr/4qXbhwgY6Pj1/kK//+tfF4TI888gg98sgjBIB++7d/mx555BF66qmniOjO+uTXf/3X6e6776Y/+7M/o7/4i7+gt73tbfS6172OyrJ8sW7rBWsn9c94PKYPfehD9KUvfYm++93v0mc/+1l605veRHfddddLpn/+0T/6RzQajehzn/scXbt2zf/MZjO/zUt5DN2uf36QY+hUGi8ion/5L/8l3XfffZQkCf3kT/5kjar5Umnvfve76cKFCxTHMV28eJHe9a530WOPPea/N8bQhz/8YTp//jylaUo/+7M/S48++uiLeMXf//bZz36WACz9vOc97yGiO+uT+XxODz/8MG1vb1O326V3vOMd9PTTT78Id/PCt5P6Zzab0UMPPURnzpyhOI7p3nvvpfe85z1L9/7D3D9tfQOAPvaxj/ltXspj6Hb984McQ+uSKOu2buu2but26tqpi3mt27qt27qt27qtjde6rdu6rdu6nbq2Nl7rtm7rtm7rdura2nit27qt27qt26lra+O1buu2buu2bqeurY3Xuq3buq3bup26tjZe67Zu67Zu63bq2tp4rdu6rdu6rdupa2vjtW7rtm7rtm6nrq2N17qt27qt27qdurY2Xuu2buu2but26traeK3buq3buq3bqWv/L5a2Lmh9XynJAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.imshow(x_hat.squeeze().detach().cpu().numpy()[:,:, 128])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cb7d2fa-d409-43f9-84e0-543c70446771",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ddc708fd-e825-4f80-bcb8-552cf4c06903",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20b7d868-16cb-49c6-82c5-87cc001bc460",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "66673a17-bcfe-4a3e-b2d2-d8ed3c3b4a17",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([512, 1, 8, 8, 8])"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k_rec.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "408ca98d-0a33-4400-9ec5-d5ec24e5ed59",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor(True, device='cuda:10')"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(k_dec == k_rec).all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f4b017b-78b9-4b8d-8477-531194c30ab3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "e8f9c26a-0148-4f5c-84c9-8cb798f75fab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# todo: upsampling, then test if strided convolution works"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b71cc606-00fc-43b5-8a9e-f17e3a232417",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "1bfa0279-c4dd-4cbb-91c7-2b71a3a533b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([16, 1, 4, 4])\n"
+     ]
+    }
+   ],
+   "source": [
+    "K_2d = build_2d_wavelet_packet_kernel(lo, hi, levels=2)\n",
+    "print(K_2d.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "2baae8b6-bc02-4a7b-94b7-5474822c0377",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[[ 0.2500,  0.2500,  0.2500,  0.2500],\n",
+       "          [ 0.2500,  0.2500,  0.2500,  0.2500],\n",
+       "          [ 0.2500,  0.2500,  0.2500,  0.2500],\n",
+       "          [ 0.2500,  0.2500,  0.2500,  0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[-0.2500, -0.2500,  0.2500,  0.2500],\n",
+       "          [-0.2500, -0.2500,  0.2500,  0.2500],\n",
+       "          [-0.2500, -0.2500,  0.2500,  0.2500],\n",
+       "          [-0.2500, -0.2500,  0.2500,  0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[ 0.2500, -0.2500,  0.2500, -0.2500],\n",
+       "          [ 0.2500, -0.2500,  0.2500, -0.2500],\n",
+       "          [ 0.2500, -0.2500,  0.2500, -0.2500],\n",
+       "          [ 0.2500, -0.2500,  0.2500, -0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[-0.2500,  0.2500,  0.2500, -0.2500],\n",
+       "          [-0.2500,  0.2500,  0.2500, -0.2500],\n",
+       "          [-0.2500,  0.2500,  0.2500, -0.2500],\n",
+       "          [-0.2500,  0.2500,  0.2500, -0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[-0.2500, -0.2500, -0.2500, -0.2500],\n",
+       "          [-0.2500, -0.2500, -0.2500, -0.2500],\n",
+       "          [ 0.2500,  0.2500,  0.2500,  0.2500],\n",
+       "          [ 0.2500,  0.2500,  0.2500,  0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[ 0.2500,  0.2500, -0.2500, -0.2500],\n",
+       "          [ 0.2500,  0.2500, -0.2500, -0.2500],\n",
+       "          [-0.2500, -0.2500,  0.2500,  0.2500],\n",
+       "          [-0.2500, -0.2500,  0.2500,  0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[-0.2500,  0.2500, -0.2500,  0.2500],\n",
+       "          [-0.2500,  0.2500, -0.2500,  0.2500],\n",
+       "          [ 0.2500, -0.2500,  0.2500, -0.2500],\n",
+       "          [ 0.2500, -0.2500,  0.2500, -0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[ 0.2500, -0.2500, -0.2500,  0.2500],\n",
+       "          [ 0.2500, -0.2500, -0.2500,  0.2500],\n",
+       "          [-0.2500,  0.2500,  0.2500, -0.2500],\n",
+       "          [-0.2500,  0.2500,  0.2500, -0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[ 0.2500,  0.2500,  0.2500,  0.2500],\n",
+       "          [-0.2500, -0.2500, -0.2500, -0.2500],\n",
+       "          [ 0.2500,  0.2500,  0.2500,  0.2500],\n",
+       "          [-0.2500, -0.2500, -0.2500, -0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[-0.2500, -0.2500,  0.2500,  0.2500],\n",
+       "          [ 0.2500,  0.2500, -0.2500, -0.2500],\n",
+       "          [-0.2500, -0.2500,  0.2500,  0.2500],\n",
+       "          [ 0.2500,  0.2500, -0.2500, -0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[ 0.2500, -0.2500,  0.2500, -0.2500],\n",
+       "          [-0.2500,  0.2500, -0.2500,  0.2500],\n",
+       "          [ 0.2500, -0.2500,  0.2500, -0.2500],\n",
+       "          [-0.2500,  0.2500, -0.2500,  0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[-0.2500,  0.2500,  0.2500, -0.2500],\n",
+       "          [ 0.2500, -0.2500, -0.2500,  0.2500],\n",
+       "          [-0.2500,  0.2500,  0.2500, -0.2500],\n",
+       "          [ 0.2500, -0.2500, -0.2500,  0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[-0.2500, -0.2500, -0.2500, -0.2500],\n",
+       "          [ 0.2500,  0.2500,  0.2500,  0.2500],\n",
+       "          [ 0.2500,  0.2500,  0.2500,  0.2500],\n",
+       "          [-0.2500, -0.2500, -0.2500, -0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[ 0.2500,  0.2500, -0.2500, -0.2500],\n",
+       "          [-0.2500, -0.2500,  0.2500,  0.2500],\n",
+       "          [-0.2500, -0.2500,  0.2500,  0.2500],\n",
+       "          [ 0.2500,  0.2500, -0.2500, -0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[-0.2500,  0.2500, -0.2500,  0.2500],\n",
+       "          [ 0.2500, -0.2500,  0.2500, -0.2500],\n",
+       "          [ 0.2500, -0.2500,  0.2500, -0.2500],\n",
+       "          [-0.2500,  0.2500, -0.2500,  0.2500]]],\n",
+       "\n",
+       "\n",
+       "        [[[ 0.2500, -0.2500, -0.2500,  0.2500],\n",
+       "          [-0.2500,  0.2500,  0.2500, -0.2500],\n",
+       "          [-0.2500,  0.2500,  0.2500, -0.2500],\n",
+       "          [ 0.2500, -0.2500, -0.2500,  0.2500]]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "K_2d"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "1fe901fa-f4c7-479f-afbe-66f091890ba8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0.7071, 0.0000, 0.0000, 0.0000, 0.7071]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zero_insert_1d(lo, stride=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "id": "f1ea9eff-f3e0-48c8-8dcf-a3b3d5663379",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[-0.5000,  0.5000,  0.5000, -0.5000]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 43,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cascade_1d_kernels([lo, lo])\n",
+    "\n",
+    "cascade_1d_kernels([lo, hi])\n",
+    "\n",
+    "cascade_1d_kernels([hi, lo])\n",
+    "\n",
+    "cascade_1d_kernels([hi, hi])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ed81793e-f37b-41a3-a9f4-32321a38ffeb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01051056-40f7-4a5e-bc31-ea6ceeb2184d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb67184a-18ce-4d1f-af48-380348636cf9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 222,
+   "id": "be37abef-014a-4060-882e-b951e39a376e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k = build_wavelet_kernel_nd(lo.squeeze(), hi.squeeze(), ndims=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 254,
+   "id": "e75d6278-f009-4f1e-a561-12e9ae37c94a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0.7071, 0.7071]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 254,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 255,
+   "id": "dfb0fc21-c6ce-4398-b247-581832b28f9f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 2])"
+      ]
+     },
+     "execution_count": 255,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lo.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 262,
+   "id": "f9886066-b434-4c1d-afde-050ae0e3d866",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k = lo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 263,
+   "id": "27561963-6769-41c9-9995-028422b1cbac",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0.7071, 0.7071]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 263,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 264,
+   "id": "5bb857ac-7335-4ebb-a4ba-310034fe72e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 2])"
+      ]
+     },
+     "execution_count": 264,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 265,
+   "id": "7d44f698-e14b-45ae-b4cb-583b39356df7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k_up = zero_insert_nd(k, stride=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 266,
+   "id": "683f562c-588e-4bf1-ba8c-73a1559bd5bd",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 3])"
+      ]
+     },
+     "execution_count": 266,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k_up.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 267,
+   "id": "9862a543-4b18-4604-9934-15ef8e7406a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k2 = F.conv1d(k, k_up, padding=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 268,
+   "id": "70f519cc-ae3b-4d5e-ba10-4fa88ca40bce",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 4])"
+      ]
+     },
+     "execution_count": 268,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k2.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 269,
+   "id": "6c3d1f66-4a1c-4772-93e7-f862aa9cfd5a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k_up2 = zero_insert_nd(k, stride=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 270,
+   "id": "07c04a2f-e0bd-419f-8d11-81955f650e28",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 5])"
+      ]
+     },
+     "execution_count": 270,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k_up2.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 271,
+   "id": "403129e3-e7ed-49b6-9f9f-f1420e0ae0cc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k3 =  F.conv1d(k2, k_up2, padding=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 272,
+   "id": "d60c73d5-35c5-4b83-9457-f1d8851a98e4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 8])"
+      ]
+     },
+     "execution_count": 272,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k3.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c89dcf74-0b62-49be-85e9-18a6e954874a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "834ea59e-755c-4cd0-b6a8-0725bf54b543",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0.7071, 0.7071]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "699615fa-996f-4a45-addf-8e3658ded9fb",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[ 0.7071, -0.7071]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "3f5857d7-1ecb-4b79-9611-a06256d26be5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tmp = cascade_1d_kernels([lo_rec, hi_rec])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "d2cf187c-78a6-4f0c-8612-af42f2eae4f5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 4])"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tmp.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "9a0c857c-bedb-4986-9302-ad7335bf5f5f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[-0.5000, -0.5000,  0.5000,  0.5000]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tmp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f7c5d5ee-5803-49f0-a82d-68838e2f0981",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf1349ba-4f66-46b3-a976-2bf6bcc4645d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 348,
+   "id": "fa4a7c84-0969-40c3-871a-bf15faf9b38c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import torch.nn as nn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 353,
+   "id": "ec9e0385-b34c-42cf-bba5-0b9ebc518c7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MLP(nn.Module):\n",
+    "    def __init__(self, inp_feat, n_feats, act=nn.ReLU(True)):\n",
+    "        super().__init__()\n",
+    "        self.body = nn.Sequential(\n",
+    "            *[\n",
+    "                nn.Linear(inp_feat, n_feats),\n",
+    "                act,\n",
+    "                nn.Linear(n_feats, n_feats), \n",
+    "                act,\n",
+    "                nn.Linear(n_feats, inp_feat), \n",
+    "            ]\n",
+    "        )\n",
+    "\n",
+    "    def forward(self, x):\n",
+    "        return self.body(x)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 360,
+   "id": "3ad2b38b-e54f-4681-ad2e-5c3e0070711e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mlp = MLP(256*256*256, 128).to(device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80b07f75-3ad4-47b0-9f3b-95b85052106e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 359,
+   "id": "f4cf5dfe-42eb-4b8c-85dc-3469a95f7cea",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "17.179869184"
+      ]
+     },
+     "execution_count": 359,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(256*256*256*256) * 32 / 8e9"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "edec475f-8ed6-4bbb-aa0a-b71ec61519fe",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "205b1893-b3c4-4903-ba94-bbad2b3ecf40",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 345,
+   "id": "514ee3fe-f8d1-49d2-8aa3-1a20691b3243",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[-0.5000,  0.5000,  0.5000, -0.5000]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 345,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tmp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8ced2f50-67b3-4902-b266-2f145220c3d5",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 292,
+   "id": "949f6251-d183-4e06-b8f8-f20937229ff5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 16])"
+      ]
+     },
+     "execution_count": 292,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tmp.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 293,
+   "id": "e9b86bd3-2f5b-4d1b-b766-81461538a97d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0.2500, 0.2500, 0.2500, 0.2500, 0.2500, 0.2500, 0.2500, 0.2500,\n",
+       "          0.2500, 0.2500, 0.2500, 0.2500, 0.2500, 0.2500, 0.2500, 0.2500]]],\n",
+       "       device='cuda:9')"
+      ]
+     },
+     "execution_count": 293,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tmp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "151df728-d492-49f0-84f2-a5cf460a8e50",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 279,
+   "id": "1faf85b7-7cb9-4c2e-baaa-37a3d1cfdfea",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0.3536, 0.3536, 0.3536, 0.3536]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 279,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "tmp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71893d66-c61a-4edf-907d-09fe6b23e034",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 273,
+   "id": "b647e917-647b-4a28-b7ff-c57fd1ab70c7",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0.3536, 0.3536, 0.3536, 0.3536, 0.3536, 0.3536, 0.3536, 0.3536]]],\n",
+       "       device='cuda:9')"
+      ]
+     },
+     "execution_count": 273,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 275,
+   "id": "960ff800-f021-4048-ae12-11a9dbdb7672",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0.5000, 0.5000, 0.0000, 0.0000, 0.5000, 0.5000]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 275,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "F.conv1d(k, k, dilation=4, padding=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe56b104-da27-4ce8-9e5c-657198d012af",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a05e7a6a-67e7-43fc-9191-b103b068ef1c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "75c14851-8a09-49e1-9dc7-8f8bc86d164d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4479fcb2-3eff-41b1-9d78-714e8c24c577",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 178,
+   "id": "8787bd00-ebb0-4548-a0a0-3fe2a3469469",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 3])"
+      ]
+     },
+     "execution_count": 178,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k_up.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 211,
+   "id": "1a1ccbd3-94eb-499b-adb8-d984a70793ab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k_up = zero_insert_nd(k, stride=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 212,
+   "id": "a4017367-2293-48f8-b053-7e1059a9e955",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[[[ 0.3536,  0.0000,  0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.3536,  0.0000,  0.3536]],\n",
+       "\n",
+       "          [[ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000]],\n",
+       "\n",
+       "          [[ 0.3536,  0.0000,  0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.3536,  0.0000,  0.3536]]]],\n",
+       "\n",
+       "\n",
+       "\n",
+       "        [[[[ 0.3536,  0.0000, -0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.3536,  0.0000, -0.3536]],\n",
+       "\n",
+       "          [[ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000]],\n",
+       "\n",
+       "          [[ 0.3536,  0.0000, -0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.3536,  0.0000, -0.3536]]]],\n",
+       "\n",
+       "\n",
+       "\n",
+       "        [[[[ 0.3536,  0.0000,  0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [-0.3536,  0.0000, -0.3536]],\n",
+       "\n",
+       "          [[ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000]],\n",
+       "\n",
+       "          [[ 0.3536,  0.0000,  0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [-0.3536,  0.0000, -0.3536]]]],\n",
+       "\n",
+       "\n",
+       "\n",
+       "        [[[[ 0.3536,  0.0000, -0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [-0.3536,  0.0000,  0.3536]],\n",
+       "\n",
+       "          [[ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000]],\n",
+       "\n",
+       "          [[ 0.3536,  0.0000, -0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [-0.3536,  0.0000,  0.3536]]]],\n",
+       "\n",
+       "\n",
+       "\n",
+       "        [[[[ 0.3536,  0.0000,  0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.3536,  0.0000,  0.3536]],\n",
+       "\n",
+       "          [[ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000]],\n",
+       "\n",
+       "          [[-0.3536,  0.0000, -0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [-0.3536,  0.0000, -0.3536]]]],\n",
+       "\n",
+       "\n",
+       "\n",
+       "        [[[[ 0.3536,  0.0000, -0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.3536,  0.0000, -0.3536]],\n",
+       "\n",
+       "          [[ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000]],\n",
+       "\n",
+       "          [[-0.3536,  0.0000,  0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [-0.3536,  0.0000,  0.3536]]]],\n",
+       "\n",
+       "\n",
+       "\n",
+       "        [[[[ 0.3536,  0.0000,  0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [-0.3536,  0.0000, -0.3536]],\n",
+       "\n",
+       "          [[ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000]],\n",
+       "\n",
+       "          [[-0.3536,  0.0000, -0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.3536,  0.0000,  0.3536]]]],\n",
+       "\n",
+       "\n",
+       "\n",
+       "        [[[[ 0.3536,  0.0000, -0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [-0.3536,  0.0000,  0.3536]],\n",
+       "\n",
+       "          [[ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.0000,  0.0000,  0.0000]],\n",
+       "\n",
+       "          [[-0.3536,  0.0000,  0.3536],\n",
+       "           [ 0.0000,  0.0000,  0.0000],\n",
+       "           [ 0.3536,  0.0000, -0.3536]]]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 212,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k_up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 213,
+   "id": "800927db-4adf-4b4b-ba36-ff5d4cb43f90",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "RuntimeError",
+     "evalue": "Expected 2D (unbatched) or 3D (batched) input to conv1d, but got input of size: [8, 1, 2, 2, 2]",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[213], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m F\u001b[38;5;241m.\u001b[39mconv1d(k, k_up, padding\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m, stride\u001b[38;5;241m=\u001b[39m\u001b[38;5;241m2\u001b[39m)\n",
+      "\u001b[0;31mRuntimeError\u001b[0m: Expected 2D (unbatched) or 3D (batched) input to conv1d, but got input of size: [8, 1, 2, 2, 2]"
+     ]
+    }
+   ],
+   "source": [
+    "F.conv1d(k, k_up, padding=2, stride=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "311a0909-ae4e-4eb3-9799-214b8ecf45c3",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5cc9a0e3-e29e-441d-8422-48f643b7e413",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29c5892d-50c1-482c-b995-6ebe7c3b9520",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "id": "3ba3665c-4dbe-4f13-9f64-eeabd951f5c8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([2, 1, 1, 1, 3])"
+      ]
+     },
+     "execution_count": 150,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k_up.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 151,
+   "id": "5092af3f-1b78-4ebe-976a-4e9d08ec1705",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "torch.Size([2, 1, 2])\n",
+      "torch.Size([2, 1, 3])\n"
+     ]
+    },
+    {
+     "ename": "RuntimeError",
+     "evalue": "expected padding to be a single integer value or a list of 1 values to match the convolution dimensions, but got padding=[0, 0, 2, 2]",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[151], line 1\u001b[0m\n\u001b[0;32m----> 1\u001b[0m cascade_nd_kernels(k, k_up)\u001b[38;5;241m.\u001b[39mshape\n",
+      "Cell \u001b[0;32mIn[147], line 14\u001b[0m, in \u001b[0;36mcascade_nd_kernels\u001b[0;34m(k1, k2)\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[38;5;28mprint\u001b[39m(k1\u001b[38;5;241m.\u001b[39mshape)\n\u001b[1;32m      9\u001b[0m \u001b[38;5;28mprint\u001b[39m(k2\u001b[38;5;241m.\u001b[39mshape)\n\u001b[1;32m     11\u001b[0m \u001b[38;5;28;01mmatch\u001b[39;00m ndims:\n\u001b[1;32m     12\u001b[0m     \u001b[38;5;28;01mcase\u001b[39;00m \u001b[38;5;241m1\u001b[39m:\n\u001b[1;32m     13\u001b[0m         padding \u001b[38;5;241m=\u001b[39m (\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m, padding, padding)\n\u001b[0;32m---> 14\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mconv1d(k1, k2, padding\u001b[38;5;241m=\u001b[39mpadding)\n\u001b[1;32m     15\u001b[0m     \u001b[38;5;28;01mcase\u001b[39;00m \u001b[38;5;241m2\u001b[39m:\n\u001b[1;32m     16\u001b[0m         padding \u001b[38;5;241m=\u001b[39m (\u001b[38;5;241m0\u001b[39m, \u001b[38;5;241m0\u001b[39m, padding, padding)\n\u001b[1;32m     17\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mconv2d(k1, k2, padding\u001b[38;5;241m=\u001b[39mpadding)\n\u001b[1;32m     18\u001b[0m     \u001b[38;5;28;01mcase\u001b[39;00m \u001b[38;5;241m3\u001b[39m:\n\u001b[1;32m     19\u001b[0m         \u001b[38;5;28;01mreturn\u001b[39;00m F\u001b[38;5;241m.\u001b[39mconv3d(k1, k2, padding\u001b[38;5;241m=\u001b[39mpadding)\n\u001b[1;32m     20\u001b[0m     \u001b[38;5;28;01mcase\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01m_\u001b[39;00m:\n\u001b[1;32m     21\u001b[0m         \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mValueError\u001b[39;00m()\n",
+      "\u001b[0;31mRuntimeError\u001b[0m: expected padding to be a single integer value or a list of 1 values to match the convolution dimensions, but got padding=[0, 0, 2, 2]"
+     ]
+    }
+   ],
+   "source": [
+    "cascade_nd_kernels(k, k_up).shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0850f22-c179-4eff-b837-9951e3c61e91",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "id": "b5671dbd-18fe-4be6-9cbc-df827fde49fa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "k_up = zero_insert_nd(k, stride=2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "d64ea0da-4eb0-4664-be04-e0f97d067878",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([2, 1, 1, 1, 3])"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k_up.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "eb13c8eb-af34-49d7-ad9a-2478acf102f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[ 0.7071,  0.0000,  0.0000,  0.0000,  0.7071],\n",
+       "        [ 0.7071,  0.0000,  0.0000,  0.0000, -0.7071]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k_up.squeeze()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "ce2901dc-a5e6-42da-a970-c1cdf40ac71c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'torch.cuda.FloatTensor'"
+      ]
+     },
+     "execution_count": 50,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "k_up.type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "f93486bb-ae2b-4001-9e6d-17422e540e46",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 2])"
+      ]
+     },
+     "execution_count": 51,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lo.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "cf266c86-50d8-4e32-bb1e-b6c40085020b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "torch.Size([1, 1, 2])"
+      ]
+     },
+     "execution_count": 52,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "hi.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "050d36b9-fdd4-4d2f-b990-8678298ee0db",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0.7071, 0.7071]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lo"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "75fe7e2e-a675-4a80-abdc-d7c5993522b5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "tensor([[[0.5000, 1.0000, 0.5000]]], device='cuda:9')"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "torch.conv1d(lo, lo, padding=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97f07e83-be9e-44a3-9f21-306b1db3cb29",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Instead of recursing a tree, we compose all the convolutions and all the resampling using the first and second Noble identities. We then do a single ND strided (transposed) convolution, yielding the output in a single step.

This only works for haar and db1 wavelets for now, and requires a power-of-two sized signal.